### PR TITLE
Add cache policy for Menu that called on every route change

### DIFF
--- a/Sig.App.Frontend/src/components/app/profile-menu.vue
+++ b/Sig.App.Frontend/src/components/app/profile-menu.vue
@@ -110,7 +110,8 @@ function getUserProfile() {
     `,
     null,
     () => ({
-      enabled: isLoggedIn.value
+      enabled: isLoggedIn.value,
+      fetchPolicy: "cache-first"
     })
   );
 

--- a/Sig.App.Frontend/src/components/app/secondary-menu.vue
+++ b/Sig.App.Frontend/src/components/app/secondary-menu.vue
@@ -108,14 +108,16 @@ const showSecondaryMenu = computed(() => {
 
 const { result } = useQuery(
   gql`
-    query Projects {
+    query SecondaryMenuProjects {
       projects {
         id
         name
         administrationSubscriptionsOffPlatform
       }
     }
-  `
+  `,
+  {},
+  { fetchPolicy: "cache-first" }
 );
 const projects = useResult(result);
 


### PR DESCRIPTION
Je soupçone que le problème de threading venait du fait qu'on a pleins de calls non nécessaire qui remplissait les pool connections.