### PR TITLE
Fix issue with board size height

### DIFF
--- a/Sig.App.Frontend/src/components/ui/table/index.vue
+++ b/Sig.App.Frontend/src/components/ui/table/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="pf-table flex flex-col relative">
-    <div class="pf-table__overflowing-content overflow-auto -mx-section md:-mx-8 max-h-simple-table-height">
+    <div class="pf-table__overflowing-content overflow-auto -mx-section md:-mx-8">
       <div class="pb-2 align-middle inline-block min-w-full px-section md:px-8">
         <div class="" :class="{ 'pb-12': slots.floatingActions || hasBottomPadding }">
           <table class="min-w-full divide-y-2 divide-primary-900 dark:divide-grey-700">


### PR DESCRIPTION
J'ai enlever une class qui semblait poser problème au niveau du calcule. Maintenant, les UiTable affiche sans deuxième scroll-bar dans le site web. Ça semble bien fonctionner maintenant, mais j'aimerais avoir la vision d'Anne la dessus.