### PR TITLE
Return total budget allowance only if the budget is not expired

### DIFF
--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetOrganizationBudgetAllowanceTotal.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetOrganizationBudgetAllowanceTotal.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using NodaTime;
 using Sig.App.Backend.DbModel;
 
 namespace Sig.App.Backend.Requests.Queries.DataLoaders
@@ -12,19 +13,23 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public class Query : BaseQuery { }
 
         private readonly AppDbContext db;
+        private readonly IClock clock;
 
-        public GetOrganizationBudgetAllowanceTotal(AppDbContext db)
+        public GetOrganizationBudgetAllowanceTotal(AppDbContext db, IClock clock)
         {
             this.db = db;
+            this.clock = clock;
         }
 
         public override async Task<IDictionary<long, decimal>> Handle(Query request, CancellationToken cancellationToken)
         {
             var results = await db.BudgetAllowances
+                .Include(x => x.Subscription)
                 .Where(x => request.Ids.Contains(x.OrganizationId))
                 .ToListAsync();
 
-            var groups = results.GroupBy(x => x.OrganizationId);
+            var now = clock.GetCurrentInstant().ToDateTimeUtc();
+            var groups = results.Where(x => x.Subscription.GetExpirationDate(clock) > now).GroupBy(x => x.OrganizationId);
 
             return groups.ToDictionary(x => x.Key, x => x.Sum(x => x.AvailableFund));
         }


### PR DESCRIPTION
[[Organismes] Ne pas compter des abonnements expirés / terminés dans le total d'une enveloppe](https://sigmund-ca.atlassian.net/browse/CRCL-1747)