### PR TITLE
Participant-e supprimé-e, les fonds ne sont pas retournés à l'enveloppe

### DIFF
--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/DeleteBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/DeleteBeneficiary.cs
@@ -41,7 +41,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
                 throw new BeneficiaryNotFoundException();
             }
             
-            if (HaveAnyActiveSubscription(beneficiary))
+            if (HaveAnySubscriptionNotExpired(beneficiary))
             {
                 logger.LogWarning("[Mutation] DeleteBeneficiary - BeneficiaryCantHaveActiveSubscriptionException");
                 throw new BeneficiaryCantHaveActiveSubscriptionException();
@@ -68,9 +68,9 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
             logger.LogInformation($"[Mutation] DeleteBeneficiary - Beneficiary deleted ({beneficiaryId}, {beneficiary.Firstname} {beneficiary.Lastname})");
         }
 
-        private bool HaveAnyActiveSubscription(Beneficiary beneficiary)
+        private bool HaveAnySubscriptionNotExpired(Beneficiary beneficiary)
         {
-            var haveAnyActiveSubscription = false;
+            var haveAnySubscriptionNotExpired = false;
             var today = clock
                 .GetCurrentInstant()
                 .ToDateTimeUtc();
@@ -79,11 +79,11 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
             {
                 if (sub.Subscription.EndDate >= today)
                 {
-                    haveAnyActiveSubscription = true;
+                    haveAnySubscriptionNotExpired = true;
                 }
             }
 
-            return haveAnyActiveSubscription;
+            return haveAnySubscriptionNotExpired;
         }
 
         [MutationInput]

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/DeleteBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/DeleteBeneficiary.cs
@@ -77,7 +77,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             foreach (var sub in beneficiary.Subscriptions)
             {
-                if (sub.Subscription.StartDate <= today && sub.Subscription.EndDate >= today)
+                if (sub.Subscription.EndDate >= today)
                 {
                     haveAnyActiveSubscription = true;
                 }

--- a/Sig.App.Frontend/src/views/beneficiary/DeleteBeneficiary.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/DeleteBeneficiary.vue
@@ -5,14 +5,16 @@
 		"delete-text-error": "Text must match participant's first and last name",
 		"delete-text-label": "Type the participant's name to confirm",
 		"description": "Warning ! The deletion of <strong>{beneficiaryName}</strong> cannot be undone. If you continue, the participant and all their data will be permanently deleted.",
-		"title": "Supprimer - {beneficiaryName}"
+		"title": "Supprimer - {beneficiaryName}",
+    "beneficiary-cant-have-active-subscription-error-notification": "The participant cannot be deleted because they have an active subscription."
 	},
 	"fr": {
 		"delete-beneficiary-success-notification": "La supression a été effectuée avec succès.",
 		"delete-text-error": "Le texte doit correspondre au prénom et au nom de famille du-de la participant-e",
 		"delete-text-label": "Taper le nom du-de la participant-e pour confirmer",
 		"description": "Avertissement ! La suppression de <strong>{beneficiaryName}</strong> ne peut pas être annulée. Si vous continuez, le participant ou la participante ainsi que toutes ses données seront supprimé-e-s de façon définitive.",
-		"title": "Supprimer - {beneficiaryName}"
+		"title": "Supprimer - {beneficiaryName}",
+    "beneficiary-cant-have-active-subscription-error-notification": "Le participant ne peut pas être supprimé car il a un abonnement actif."
 	}
 }
 </i18n>
@@ -34,6 +36,7 @@ import { useQuery, useResult, useMutation } from "@vue/apollo-composable";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 
+import { useGraphQLErrorMessages } from "@/lib/helpers/error-handler";
 import { useNotificationsStore } from "@/lib/store/notifications";
 import { URL_BENEFICIARY_ADMIN } from "@/lib/consts/urls";
 
@@ -41,6 +44,14 @@ const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();
 const { addSuccess } = useNotificationsStore();
+
+// Configure les messages en lien avec les erreurs graphql susceptibles d'être lancées par ce composant
+useGraphQLErrorMessages({
+  // Ce code est lancé quand le mot de passe est invalid
+  BENEFICIARY_CANT_HAVE_ACTIVE_SUBSCRIPTION: () => {
+    return t("beneficiary-cant-have-active-subscription-error-notification");
+  }
+});
 
 const { result: resultProject } = useQuery(
   gql`


### PR DESCRIPTION
La vraie règle d'affaire est d'interdire une supression de participant si il possède un abonnement. C'était une mauvaise gestion de la supression de participant.

[JIRA](https://sigmund-ca.atlassian.net/browse/CRCL-1952)