### PR TITLE
Fix issue with negatif AddingFund used by Display balance for a specific card (it's now already calculated in the AddingFundTransaction)

### DIFF
--- a/Sig.App.Frontend/src/views/card/Balance.vue
+++ b/Sig.App.Frontend/src/views/card/Balance.vue
@@ -151,7 +151,10 @@ const programName = computed(() => {
 const getProductGroups = (funds) => {
   const productGroups = [];
   for (let fund of funds) {
-    if (fund.expirationDate > new Date().toISOString() || fund.productGroup.name === PRODUCT_GROUP_LOYALTY) {
+    if (
+      fund.availableFund > 0 &&
+      (fund.expirationDate > new Date().toISOString() || fund.productGroup.name === PRODUCT_GROUP_LOYALTY)
+    ) {
       if (productGroups.find((pg) => pg.label === fund.productGroup.name && pg.expirationDate === fund.expirationDate)) {
         productGroups.find((pg) => pg.label === fund.productGroup.name).fund += fund.amount ?? fund.availableFund;
       } else {


### PR DESCRIPTION
[JIRA](https://sigmund-ca.atlassian.net/browse/CRCL-2011)

En gros, maintenant le montant négatif est appliqué directement au autre AddingFundTransaction, donc on calculait en double ce montant spécifiquement dans cette vue.