### PR TITLE
Fix issue when assign subscription is executed with ReplicatePayment

### DIFF
--- a/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
+++ b/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
@@ -187,7 +187,7 @@ namespace Sig.App.Backend.BackgroundJobs
                 .Where(x => x.Id == subscriptionIdLong).FirstAsync();
 
             var beneficiary = await db.Beneficiaries
-                .Include(x => x.Card).ThenInclude(x => x.Transactions)
+                .Include(x => x.Card).ThenInclude(x => x.Transactions).ThenInclude(x => (x as SubscriptionAddingFundTransaction).SubscriptionType)
                 .Include(x => x.Card).ThenInclude(x => x.Funds)
                 .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(x => x.Id== beneficiaryIdLong)

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
@@ -152,7 +152,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                 {
                     var amount =
                         subscription.Types.Where(x => x.BeneficiaryTypeId == beneficiary.BeneficiaryTypeId)
-                            .Sum(x => x.Amount) * (request.ReplicatePaymentOnAttribution && beneficiary.Card != null ? paymentRemaining + 1 : paymentRemaining);
+                            .Sum(x => x.Amount) * (request.ReplicatePaymentOnAttribution && beneficiary.Card != null ? Math.Min(subscription.MaxNumberOfPayments.Value, paymentRemaining + 1) : paymentRemaining);
 
                     if (budgetAllowance.AvailableFund >= amount)
                     {


### PR DESCRIPTION
Fix issue when assign subscription is executed with ReplicatePaymentOnAttribution, but with a max count of payment

En règlant le problème, j'ai trouvé un autre problème dans la requête des transactions pour la requête AddFundToSpecificBeneficiary. Il manquait un include spécifique au **SubscriptionAddingFundTransaction**à

Donc, le problème était spécifiquement dans AssignBeneficiariesToSubscription.cs