### PR TITLE
Fix issue with errors with missed payments + maximum number of payments

### DIFF
--- a/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
+++ b/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
@@ -252,7 +252,7 @@ namespace Sig.App.Backend.BackgroundJobs
             if (beneficiary.Card != null)
             {
                 var card = beneficiary.Card;
-                if (subscription.IsSubscriptionPaymentBasedCardUsage)
+                if (subscription.IsSubscriptionPaymentBasedCardUsage && initiatedBy == null)
                 {
                     var subscriptionAddedFundCount = beneficiary.Card.Transactions.OfType<SubscriptionAddingFundTransaction>().Count(x => x.SubscriptionType.SubscriptionId == subscription.Id);
 

--- a/Sig.App.Frontend/src/views/beneficiary/AddMissedPayment.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AddMissedPayment.vue
@@ -110,6 +110,9 @@ const { result: resultBeneficiary } = useQuery(
           beneficiarySubscriptions {
             hasMissedPayment
             paymentReceived
+            paymentRemaining
+            missedPaymentCount
+            maxNumberOfPayments
             subscription {
               id
               name
@@ -160,7 +163,8 @@ const subscriptionOptions = useResult(resultBeneficiary, null, (data) => {
         label: label,
         value: x.subscription.id,
         types: x.subscription.types,
-        budgetAllowance: x.subscription.budgetAllowancesTotal
+        budgetAllowance: x.subscription.budgetAllowancesTotal,
+        isBudgetAllowanceAlreadyAllocated: x.maxNumberOfPayments - x.paymentReceived <= x.paymentRemaining
       };
     })
     .reduce(function (a, b) {
@@ -211,6 +215,11 @@ function onSubscriptionSelected(e) {
 const budgetAllowanceAvailableAfterAllocation = computed(() => {
   if (selectedSubscription.value === null) return 0;
   var selectedSubscriptionData = subscriptionOptions.value.find((x) => x.value === selectedSubscription.value);
+
+  if (selectedSubscriptionData.isBudgetAllowanceAlreadyAllocated) {
+    return selectedSubscriptionData.budgetAllowance;
+  }
+
   return selectedSubscriptionData.budgetAllowance - amountThatWillBeAllocated.value;
 });
 


### PR DESCRIPTION
[Erreurs avec le versement de paiements manqués + nombre maximum de versements #156](https://sigmund-ca.atlassian.net/browse/CRCL-2208)

Donc, le problème ce situe au niveau de l’hypothèse qui est pris en compte lorsqu’on décide d’appliquer un Versement de paiements manqués.

Actuellement, le processus d’ajout d’un Versement de paiement manqué lorsque fait à l’extérieur du processus d’ajout d’abonnement assumait l’hypothèse suivante : les fonds n’ont pas été enlevé de l’enveloppe. C’est une erreur de notre part d’avoir fait cette hypothèse puisque ce n’est premièrement pas toujours le cas et que le processus est plus complexe selon le type d’abonnement et les différentes variables des abonnements. Bref, nous devons corriger ce problème pour pouvoir permettre le bon calcul.

Dans notre cas, l’ajout d’un abonnement enlevait bien le 160$ de l’enveloppe budgétaire, mais le fait de faire le Versement de paiement manqué à l’extérieur du processus d’assignation d’abonnement enlevait de nouveau un 40$.

Pour ce qui est du calcul total (le 40$ manquant), j’ai regardé la base de données et j’ai trouvé un versement manuel sur un participant. Donc, le calcul suivant : 5 versements x 40 x 35cartes =7000$ + 40$ versement manuel.