### PR TITLE
Disabled button add cash-register to project when there's no project

### DIFF
--- a/Sig.App.Frontend/src/views/cash-register/_Form.vue
+++ b/Sig.App.Frontend/src/views/cash-register/_Form.vue
@@ -97,7 +97,7 @@
         <div class="pt-5">
           <div class="flex gap-x-6 items-center justify-end">
             <PfButtonAction btn-style="link" :label="t('cancel')" @click="closeModal" />
-            <PfButtonAction class="px-8" :label="submitBtn" type="submit" />
+            <PfButtonAction class="px-8" :label="submitBtn" type="submit" :disabled="projectOptions.length === 0" />
           </div>
         </div>
       </template>


### PR DESCRIPTION
[NTH - Disablé le bouton "Ajouter" si tous les groupes de commerces et programme sont déjà associés à la caisse](https://sigmund-ca.atlassian.net/browse/CRCL-2225)