### PR TITLE
Fix issue with missed payment budget allowance calculated with all the budget-allowance instead of budget for Beneficiary Organization

### DIFF
--- a/Sig.App.Frontend/src/views/beneficiary/AddMissedPayment.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AddMissedPayment.vue
@@ -107,6 +107,9 @@ const { result: resultBeneficiary } = useQuery(
           beneficiaryType {
             id
           }
+          organization {
+            id
+          }
           beneficiarySubscriptions {
             hasMissedPayment
             paymentReceived
@@ -126,6 +129,13 @@ const { result: resultBeneficiary } = useQuery(
                   id
                 }
               }
+              budgetAllowances {
+                id
+                availableFund
+                organization {
+                  id
+                }
+              }
             }
           }
         }
@@ -140,6 +150,7 @@ const { result: resultBeneficiary } = useQuery(
 const beneficiary = useResult(resultBeneficiary, null, (data) => data.beneficiary);
 
 const subscriptionOptions = useResult(resultBeneficiary, null, (data) => {
+  var localBeneficiary = data.beneficiary;
   return data.beneficiary.beneficiarySubscriptions
     .filter(
       (x) =>
@@ -162,7 +173,8 @@ const subscriptionOptions = useResult(resultBeneficiary, null, (data) => {
         label: label,
         value: x.subscription.id,
         types: x.subscription.types,
-        budgetAllowance: x.subscription.budgetAllowancesTotal,
+        budgetAllowance: x.subscription.budgetAllowances.find((x) => x.organization.id === localBeneficiary.organization.id)
+          .availableFund,
         isBudgetAllowanceAlreadyAllocated: x.maxNumberOfPayments - x.paymentReceived <= x.paymentRemaining
       };
     })


### PR DESCRIPTION
[[Versement d'un paiement manqué] Indiquer seulement le montant restant de l’enveloppe sélectionnée selon le groupe du participant](https://sigmund-ca.atlassian.net/browse/CRCL-2185)