### PR TITLE
Set dollars in report as money format (0.00 $)

### DIFF
--- a/Sig.App.Backend/Helpers/ExcelGenerator.DataWorksheet.cs
+++ b/Sig.App.Backend/Helpers/ExcelGenerator.DataWorksheet.cs
@@ -73,6 +73,17 @@ namespace Sig.App.Backend.Helpers
                 );
             }
 
+            public DataWorksheet<T> Column(string heading, Func<T, object> getValue, string numberFormat)
+            {
+                return Column(
+                    x => x.Value = heading,
+                    (item, cell) => {
+                        cell.Style.NumberFormat.Format = numberFormat;
+                        cell.Value = TransformValue(getValue(item));
+                     }
+                );
+            }
+
             public DataWorksheet<T> AddFooterRow(Action<IXLRow> renderRow)
             {
                 footerRenderers.Add(renderRow);

--- a/Sig.App.Backend/Requests/Queries/Beneficiaries/ExportBeneficiariesList.cs
+++ b/Sig.App.Backend/Requests/Queries/Beneficiaries/ExportBeneficiariesList.cs
@@ -195,8 +195,8 @@ namespace Sig.App.Backend.Requests.Commands.Queries.Beneficiaries
             }
             
             dataWorksheet.Column("Catégorie/Category", x => x.BeneficiaryType.GetKeys().First());
-            dataWorksheet.Column("Solde total/Total balance", x => x.Card != null ? x.Card.TotalFund().ToString("C", request.Language == Language.French ? CultureInfo.CreateSpecificCulture("fr-CA") : CultureInfo.CreateSpecificCulture("en-CA")) : "");
-            dataWorksheet.Column("Solde abonnement/Subscription balance", x => x.Card != null ? x.Card.TotalSubscriptionFund().ToString("C", request.Language == Language.French ? CultureInfo.CreateSpecificCulture("fr-CA") : CultureInfo.CreateSpecificCulture("en-CA")) : "");
+            dataWorksheet.Column("Solde total/Total balance", x => x.Card != null ? x.Card.TotalFund() : "", "0.00 $");
+            dataWorksheet.Column("Solde abonnement/Subscription balance", x => x.Card != null ? x.Card.TotalSubscriptionFund() : "", "0.00 $");
 
             foreach (var productGroup in productGroups)
             {
@@ -205,26 +205,26 @@ namespace Sig.App.Backend.Requests.Commands.Queries.Beneficiaries
                     dataWorksheet.Column("Montant/Amount - " + productGroup.Name, x => {
                         if (x.Card != null)
                         {
-                            return x.Card.Funds.FirstOrDefault(x => x.ProductGroupId == productGroup.Id)?.Amount.ToString("C", request.Language == Language.French ? CultureInfo.CreateSpecificCulture("fr-CA") : CultureInfo.CreateSpecificCulture("en-CA"));
+                            return x.Card.Funds.FirstOrDefault(x => x.ProductGroupId == productGroup.Id)?.Amount;
                         }
                         return null;
-                    });
+                    }, "0.00 $");
                 }
             }
 
-            dataWorksheet.Column("Solde carte-cadeau/Gift card balance", x => x.Card != null ? x.Card.LoyaltyFund().ToString("C", request.Language == Language.French ? CultureInfo.CreateSpecificCulture("fr-CA") : CultureInfo.CreateSpecificCulture("en-CA")) : "");
+            dataWorksheet.Column("Solde carte-cadeau/Gift card balance", x => x.Card != null ? x.Card.LoyaltyFund() : null, "0.00 $");
             dataWorksheet.Column("Dépenses/Expenses", x =>
             {
                 if (x.Card != null)
                 {
                     var transactions = x.Card.Transactions;
-                    return transactions.Where(x => x.GetType() == typeof(PaymentTransaction)).Sum(x => x.Amount).ToString("C", request.Language == Language.French ? CultureInfo.CreateSpecificCulture("fr-CA") : CultureInfo.CreateSpecificCulture("en-CA"));
+                    return transactions.Where(x => x.GetType() == typeof(PaymentTransaction)).Sum(x => x.Amount);
                 }
                 else
                 {
                     return "";
                 }
-            });
+            }, "0.00 $");
             dataWorksheet.Column("ID carte/Card ID", x => x.Card != null ? x.Card.ProgramCardId : "");
             dataWorksheet.Column("Numéro carte/Card Number", x => x.Card != null ? x.Card.CardNumber.Replace('-', ' ') : "");
             dataWorksheet.Column("Abonnements/Subscriptions", x => GetActiveSubscriptions(x.Subscriptions));


### PR DESCRIPTION
[[Rapports] Amélioration du traitement des montants en dollars dans les rapports exportés](https://sigmund-ca.atlassian.net/browse/CRCL-2180)

Voir les fichiers suivant et les colonnes qui ont des montants en argent. Il devrait maintenant être structurer en argent et non une string.

[815f7587-03d7-4959-831c-33289625017a.xlsx](https://github.com/user-attachments/files/19981988/815f7587-03d7-4959-831c-33289625017a.xlsx)
[Participants_SeedDev-Groupe1.xlsx](https://github.com/user-attachments/files/19981989/Participants_SeedDev-Groupe1.xlsx)
[Participants_SeedDev-Programme1.xlsx](https://github.com/user-attachments/files/19981990/Participants_SeedDev-Programme1.xlsx)