### PR TITLE
Fix issue with check for WithGiftCard / WithoutGiftCard

### DIFF
--- a/Sig.App.Backend/Requests/Queries/Transactions/SearchTransactionLogs.cs
+++ b/Sig.App.Backend/Requests/Queries/Transactions/SearchTransactionLogs.cs
@@ -121,13 +121,13 @@ namespace Sig.App.Backend.Requests.Queries.Transactions
                 }
                 else if (withGiftCard)
                 {
-                    // When the transaction is made without an organizationId, the transaction is for a gift-card
-                    query = query.Where(x => x.OrganizationId == null);
+                    // When the transaction is made without an subscriptionId, the transaction is for a gift-card
+                    query = query.Where(x => x.SubscriptionId == null);
                 }
                 else if (withoutGiftCard)
                 {
-                    // When the transaction is made with an organizationId, the transaction is not for a gift-card
-                    query = query.Where(x => x.OrganizationId != null);
+                    // When the transaction is made with an subscriptionId, the transaction is not for a gift-card
+                    query = query.Where(x => x.SubscriptionId != null);
                 }
             }
 


### PR DESCRIPTION
[Le filtre par carte-cadeau ne fonctionne pas](https://sigmund-ca.atlassian.net/browse/CRCL-2324)

Le filtre fonctionnait sauf dans le cas qu'on avait une transaction sur une carte qui avait à la fois des fonds de Subscription et des fonds de Carte-Cadeau. En regardant SubscriptionId, c'est réglé.