### PR TITLE
Fix issue with MissedPayment envelope calculation when beneficiary was previously in the subscription | Fix issue with balanceOnCard calculation when transaction don't have Card

### DIFF
--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
@@ -72,9 +72,8 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
 
             if (subscription.MaxNumberOfPayments.HasValue)
             {
-                return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && subscription.GetFirstPaymentDateTime(clock) < clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment;
+                return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && subscription.GetFirstPaymentDateTime(clock) < clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment - subscriptionPaymentRemaining;
             }
-
 
             return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment - subscriptionPaymentRemaining;
         }

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -113,7 +113,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             if (subscription.MaxNumberOfPayments.HasValue)
             {
-                if (transactions.Count() == subscription.MaxNumberOfPayments - subscriptionPaymentRemaining)
+                if (transactions.Count() >= subscription.MaxNumberOfPayments - subscriptionPaymentRemaining)
                 {
                     logger.LogWarning("[Mutation] AddMissingPayment - SubscriptionDontHaveMissedPaymentException");
                     throw new SubscriptionDontHaveMissedPaymentException();

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -113,7 +113,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             if (subscription.MaxNumberOfPayments.HasValue)
             {
-                if (transactions.Count() == subscription.MaxNumberOfPayments)
+                if (transactions.Count() == subscription.MaxNumberOfPayments - subscriptionPaymentRemaining)
                 {
                     logger.LogWarning("[Mutation] AddMissingPayment - SubscriptionDontHaveMissedPaymentException");
                     throw new SubscriptionDontHaveMissedPaymentException();

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -104,6 +104,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
             }
 
             var transactions = await db.Transactions.OfType<SubscriptionAddingFundTransaction>()
+                .Where(x => x.Status != DbModel.Enums.FundTransactionStatus.Unassigned)
                 .Include(x => x.SubscriptionType)
                 .Where(x => x.BeneficiaryId == beneficiary.Id && x.SubscriptionType.SubscriptionId == subscription.Id).ToListAsync();
 

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetSubscriptionTransactionsByBeneficiaryAndSubscriptionId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetSubscriptionTransactionsByBeneficiaryAndSubscriptionId.cs
@@ -26,7 +26,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         {
             var transactions = await db.Transactions.OfType<SubscriptionAddingFundTransaction>()
                 .Include(x => x.SubscriptionType)
-                .Where(x => x.BeneficiaryId == request.Group && request.Ids.Contains(x.SubscriptionType.SubscriptionId)).ToListAsync();
+                .Where(x => x.BeneficiaryId == request.Group && x.Status != DbModel.Enums.FundTransactionStatus.Unassigned && request.Ids.Contains(x.SubscriptionType.SubscriptionId)).ToListAsync();
 
             return transactions.ToLookup(x => x.SubscriptionType.SubscriptionId, x => new TransactionGraphType(x));
         }

--- a/Sig.App.Backend/Requests/Queries/Organizations/GetOrganizationsStats.cs
+++ b/Sig.App.Backend/Requests/Queries/Organizations/GetOrganizationsStats.cs
@@ -126,8 +126,8 @@ namespace Sig.App.Backend.Requests.Queries.Organizations
 
         public decimal GetBalanceOnCards(List<ManuallyAddingFundTransaction> manuallyAddingTransactions, List<SubscriptionAddingFundTransaction> subscriptionTransactions)
         {
-            var manuallyAddingBalance = manuallyAddingTransactions.Sum(x => x.AvailableFund);
-            var subscriptionBalance = subscriptionTransactions.Sum(x => x.AvailableFund);
+            var manuallyAddingBalance = manuallyAddingTransactions.Where(x => x.CardId != null).Sum(x => x.AvailableFund);
+            var subscriptionBalance = subscriptionTransactions.Where(x => x.CardId != null).Sum(x => x.AvailableFund);
 
             return manuallyAddingBalance + subscriptionBalance;
         }
@@ -136,7 +136,7 @@ namespace Sig.App.Backend.Requests.Queries.Organizations
         {
             var manuallyAddingAmount = manuallyAddingTransactions.Where(x => x.CardId != null).Sum(x => x.Amount);
             var subscriptionAmount = subscriptionTransactions.Where(x => x.CardId != null).Sum(x => x.Amount);
-
+            
             return manuallyAddingAmount + subscriptionAmount;
         }
 

--- a/Sig.App.Frontend/src/views/transaction/NewScan.vue
+++ b/Sig.App.Frontend/src/views/transaction/NewScan.vue
@@ -141,8 +141,9 @@ const { result, loading } = useQuery(
 
 const cashRegisters = useResult(result, [], (data) => {
   if (data.markets[0].cashRegisters.filter((x) => !x.isArchived).length === 1) {
-    changeCashRegister(data.markets[0].cashRegisters[0].id);
-    selectedCashRegisterId.value = data.markets[0].cashRegisters[0].id;
+    const cashRegister = data.markets[0].cashRegisters.filter((x) => !x.isArchived)[0];
+    changeCashRegister(cashRegister.id);
+    selectedCashRegisterId.value = cashRegister.id;
   }
 
   return data.markets[0].cashRegisters.map((cashRegister) => ({

--- a/Sig.App.Frontend/src/views/transaction/SelectMarket.vue
+++ b/Sig.App.Frontend/src/views/transaction/SelectMarket.vue
@@ -134,10 +134,13 @@ const { result: resultProjects } = useQuery(
   `
 );
 const projectMarkets = useResult(resultProjects, null, (data) => {
-  if (data.projects[0].markets.length === 1 && data.projects[0].markets[0].cashRegisters.length === 1) {
+  if (
+    data.projects[0].markets.length === 1 &&
+    data.projects[0].markets[0].cashRegisters.filter((x) => !x.isArchived).length === 1
+  ) {
     emit("onUpdateStep", TRANSACTION_STEPS_ADD, {
       marketId: data.projects[0].markets[0].id,
-      cashRegisterId: data.projects[0].markets[0].cashRegisters[0].id
+      cashRegisterId: data.projects[0].markets[0].cashRegisters.filter((x) => !x.isArchived)[0].id
     });
     return [];
   }
@@ -181,7 +184,10 @@ const { result: resultOrganizations } = useQuery(
   `
 );
 const organizationMarkets = useResult(resultOrganizations, null, (data) => {
-  if (data.organizations[0].markets.length === 1 && data.organizations[0].markets[0].cashRegisters.filter((x) => !x.isArchived).length === 1) {
+  if (
+    data.organizations[0].markets.length === 1 &&
+    data.organizations[0].markets[0].cashRegisters.filter((x) => !x.isArchived).length === 1
+  ) {
     emit("onUpdateStep", TRANSACTION_STEPS_ADD, {
       marketId: data.organizations[0].markets[0].id,
       cashRegisterId: data.organizations[0].markets[0].cashRegisters.filter((x) => !x.isArchived)[0].id


### PR DESCRIPTION
[Montants incohérents sur le Dashboard et potentiellement dans l'enveloppe? #193](https://sigmund-ca.atlassian.net/browse/CRCL-2367)

Il y avait quatre problèmes.

1. AddMissingPayment -> La liste des transactions active du candidat incluait les transactions non assigné (donc inactive) / Le calcule du nombre maximum de paiement ne prenait pas en considération les paiements futures
2. GetSubscriptionTransactionsByBeneficiaryAndSubscriptionId -> La liste des transactions active du candidat incluait les transactions non assigné (donc inactive)
3. GetOrganizationsStats -> le calcule de GetBalanceOnCards prenait la liste des transactions complète incluant les transactions sans CardId (cas lorsqu'on enlève une carte d'un participant)
4. BeneficiarySubscriptionTypeGraphType -> le calcule de HasMissedPayment ne prenait pas en considération les futures paiements si l'abonnement avait un nombre maximum de paiement.