### PR TITLE
Fix small issues in BudgetAllowanceTable

### DIFF
--- a/Sig.App.Frontend/src/components/budget-allowance/budget-allowance-table.vue
+++ b/Sig.App.Frontend/src/components/budget-allowance/budget-allowance-table.vue
@@ -1,12 +1,12 @@
 <i18n>
   {
       "en": {
-          "organization-name": "Group name",
+          "subscription-name": "Subscription",
 					"budget-allowance-original-fund": "Original fund",
 					"budget-allowance-available-fund": "Available fund",
       },
       "fr": {
-          "organization-name": "Nom du groupe",
+          "subscription-name": "Abonnement",
 					"budget-allowance-original-fund": "Fonds original",
 					"budget-allowance-available-fund": "Fonds disponible"
       }
@@ -17,7 +17,7 @@
   <UiTable v-if="props.budgetAllowances" :items="props.budgetAllowances" :cols="cols">
     <template #default="slotProps">
       <td class="py-3">
-        {{ slotProps.item.organization.name }}
+        {{ slotProps.item.subscription.name }}
       </td>
       <td class="py-3 text-right">
         {{ getMoneyFormat(slotProps.item.originalFund) }}
@@ -43,7 +43,7 @@ const props = defineProps({
 
 const cols = computed(() => {
   return [
-    { label: t("organization-name") },
+    { label: t("subscription-name") },
     { label: t("budget-allowance-original-fund"), isRight: true },
     { label: t("budget-allowance-available-fund"), isRight: true }
   ];

--- a/Sig.App.Frontend/src/views/beneficiary/AvailableAmountForAllocation.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AvailableAmountForAllocation.vue
@@ -40,9 +40,14 @@ const { result } = useQuery(
           id
           availableFund
           originalFund
-          organization {
+          subscription {
             id
             name
+            isArchived
+            isExpired
+            isFundsAccumulable
+            fundsExpirationDate
+            endDate
           }
         }
       }
@@ -56,6 +61,16 @@ const organization = useResult(result);
 
 const budgetAllowances = computed(() => {
   if (!organization.value) return [];
-  return organization.value.budgetAllowances;
+  return organization.value.budgetAllowances
+    .filter((budgetAllowance) => !budgetAllowance.subscription.isArchived && !budgetAllowance.subscription.isExpired)
+    .sort((a, b) => {
+      const dateA = a.subscription.isFundsAccumulable
+        ? new Date(a.subscription.fundsExpirationDate)
+        : new Date(a.subscription.endDate);
+      const dateB = b.subscription.isFundsAccumulable
+        ? new Date(b.subscription.fundsExpirationDate)
+        : new Date(b.subscription.endDate);
+      return dateB - dateA;
+    });
 });
 </script>

--- a/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
@@ -19,7 +19,8 @@
       "manage-participants": "Manage",
       "assign-subscriptions": "Assignments",
       "all-group": "All groups",
-      "selected-all-group-description": "Some actions are not available if all groups are selected"
+      "selected-all-group-description": "Some actions are not available if all groups are selected",
+      "available-amount-for-allocation-details": "Show details"
     },
     "fr": {
       "add-beneficiary": "Ajouter un participant",


### PR DESCRIPTION
[Ajustements post test](https://sigmund-ca.atlassian.net/browse/CRCL-2369)

- Le texte en anglais n’est pas traduit : “Show details” serait bon
- Dans le tableau, il y a une colonne “Group name” (qui est toujours juste le nom du groupe) qui devrait probablement être le nom de l’abonnement
- Des enveloppes des abonnements terminés (expirés) sont affichés
- L’ordre des enveloppes n’est pas le même que sur la page Participants

**Avant**
![image-20250701-175139](https://github.com/user-attachments/assets/6fb63abe-50f9-4569-b217-e8e01a21a3e8)

**Après**
![Capture d’écran 2025-07-03 123827](https://github.com/user-attachments/assets/87682baf-aab4-497d-8287-d797e356f0a0)