### PR TITLE
Reactivated missed payment for subscription with max payment and fix issue with Missed Payment calculation on Assign

### DIFF
--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
@@ -72,7 +72,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
 
             if (subscription.MaxNumberOfPayments.HasValue)
             {
-                return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && subscription.GetFirstPaymentDateTime(clock) < clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment - subscriptionPaymentRemaining;
+                return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && subscription.GetFirstPaymentDateTime(clock) < clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment;
             }
 
             return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment - subscriptionPaymentRemaining;

--- a/Sig.App.Backend/Gql/Schema/Query.cs
+++ b/Sig.App.Backend/Gql/Schema/Query.cs
@@ -380,6 +380,15 @@ namespace Sig.App.Backend.Gql.Schema
             });
         }
 
+        public static async Task<ForecastAddingFundTransactionForSubscriptionByBeneficiary.AddingFundTransactionForSubscriptionByBeneficiaryPayload> ForecastAddingFundTransactionForSubscriptionByBeneficiary(this GqlQuery _, Id subscriptionId, Id[] beneficiaryIds, [Inject] IMediator mediator)
+        {
+            return await mediator.Send(new ForecastAddingFundTransactionForSubscriptionByBeneficiary.Input()
+            {
+                SubscriptionId = subscriptionId,
+                Beneficiaries = beneficiaryIds
+            });
+        }
+
         public static async Task<string> GenerateTransactionsReport(this GqlQuery _, Id projectId, DateTime startDate, DateTime endDate, Id[] organizations, Id[] subscriptions, bool? withoutSubscription, Id[] categories, Id[] markets, Id[] cashRegisters, string[] transactionTypes, string[] giftCardTransactionTypes, string searchText, string timeZoneId, Language language, [Inject] IMediator mediator)
         {
             return await mediator.Send(new GenerateTransactionsReport.Input()

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
@@ -1,26 +1,28 @@
 ﻿using GraphQL.Conventions;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Sig.App.Backend.BackgroundJobs;
 using Sig.App.Backend.DbModel;
+using Sig.App.Backend.DbModel.Entities;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.DbModel.Entities.Organizations;
 using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Entities.Transactions;
+using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.Extensions;
+using Sig.App.Backend.Gql.Bases;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Helpers;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Sig.App.Backend.Gql.Bases;
-using System.Collections.Generic;
-using Sig.App.Backend.BackgroundJobs;
-using Microsoft.AspNetCore.Http;
-using Sig.App.Backend.DbModel.Entities;
 
 namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 {
@@ -143,8 +145,8 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
                     if (request.ReplicatePaymentOnAttribution && beneficiary.Card != null)
                     {
-                        var beneficiarypaymentRemaining = (request.ReplicatePaymentOnAttribution && beneficiary.Card != null ? Math.Min(subscription.MaxNumberOfPayments.HasValue ? subscription.MaxNumberOfPayments.Value : subscription.GetTotalPayment(), paymentRemaining + 1) : paymentRemaining);
-                        var amount = subscription.Types.Where(x => x.BeneficiaryTypeId == beneficiary.BeneficiaryTypeId).Sum(x => x.Amount) * beneficiarypaymentRemaining;
+                        var beneficiaryPaymentRemaining = (request.ReplicatePaymentOnAttribution && beneficiary.Card != null ? Math.Min(subscription.MaxNumberOfPayments.HasValue ? subscription.MaxNumberOfPayments.Value : subscription.GetTotalPayment(), paymentRemaining + 1) : paymentRemaining);
+                        var amount = subscription.Types.Where(x => x.BeneficiaryTypeId == beneficiary.BeneficiaryTypeId).Sum(x => x.Amount) * beneficiaryPaymentRemaining;
                         
                         if (budgetAllowance.AvailableFund >= amount)
                         {
@@ -167,9 +169,16 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             {
                 foreach (var beneficiary in beneficiaries)
                 {
-                    var amount =
-                        subscription.Types.Where(x => x.BeneficiaryTypeId == beneficiary.BeneficiaryTypeId)
-                            .Sum(x => x.Amount) * (request.ReplicatePaymentOnAttribution && beneficiary.Card != null ? Math.Min(subscription.MaxNumberOfPayments.HasValue ? subscription.MaxNumberOfPayments.Value : subscription.GetTotalPayment(), paymentRemaining + 1) : paymentRemaining);
+                    if (subscription.IsSubscriptionPaymentBasedCardUsage)
+                    {
+                        var beneficiaryTransactionForThisSubscription = await db.Transactions
+                            .Include(x => (x as SubscriptionAddingFundTransaction).SubscriptionType)
+                            .Where(x => x.BeneficiaryId == beneficiary.Id)
+                            .ToListAsync(cancellationToken);
+                        paymentRemaining = Math.Max(0, paymentRemaining - beneficiaryTransactionForThisSubscription.OfType<SubscriptionAddingFundTransaction>().Where(x => x.SubscriptionType.SubscriptionId == subscription.Id).Count());
+                    }
+
+                    var amount = subscription.Types.Where(x => x.BeneficiaryTypeId == beneficiary.BeneficiaryTypeId).Sum(x => x.Amount) * (request.ReplicatePaymentOnAttribution && beneficiary.Card != null ? Math.Min(subscription.GetTotalPayment(), paymentRemaining + 1) : paymentRemaining);
 
                     if (budgetAllowance.AvailableFund >= amount)
                     {

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -113,7 +113,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             if (subscription.MaxNumberOfPayments.HasValue)
             {
-                if (transactions.Count() >= subscription.MaxNumberOfPayments - subscriptionPaymentRemaining)
+                if (transactions.Count() == subscription.MaxNumberOfPayments)
                 {
                     logger.LogWarning("[Mutation] AddMissingPayment - SubscriptionDontHaveMissedPaymentException");
                     throw new SubscriptionDontHaveMissedPaymentException();

--- a/Sig.App.Backend/Requests/Queries/Beneficiaries/ForecastAddingFundTransactionForSubscriptionByBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Queries/Beneficiaries/ForecastAddingFundTransactionForSubscriptionByBeneficiary.cs
@@ -1,0 +1,85 @@
+﻿using GraphQL.Conventions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using Sig.App.Backend.DbModel;
+using Sig.App.Backend.DbModel.Entities.Beneficiaries;
+using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Entities.Transactions;
+using Sig.App.Backend.Extensions;
+using Sig.App.Backend.Gql.Bases;
+using Sig.App.Backend.Plugins.MediatR;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sig.App.Backend.Requests.Queries.Beneficiaries
+{
+    public class ForecastAddingFundTransactionForSubscriptionByBeneficiary : IRequestHandler<ForecastAddingFundTransactionForSubscriptionByBeneficiary.Input, ForecastAddingFundTransactionForSubscriptionByBeneficiary.AddingFundTransactionForSubscriptionByBeneficiaryPayload>
+    {
+        private IClock clock;
+        private readonly AppDbContext db;
+
+        public ForecastAddingFundTransactionForSubscriptionByBeneficiary(IClock clock, AppDbContext db)
+        {
+            this.clock = clock;
+            this.db = db;
+        }
+
+        public async Task<AddingFundTransactionForSubscriptionByBeneficiaryPayload> Handle(Input request, CancellationToken cancellationToken)
+        {
+            var today = clock.GetCurrentInstant().ToDateTimeUtc();
+
+            var subscriptionId = request.SubscriptionId.LongIdentifierForType<Subscription>();
+            var subscription = await db.Subscriptions.Include(x => x.Project).FirstOrDefaultAsync(x => x.Id == subscriptionId, cancellationToken);
+
+            if (subscription == null) throw new SubscriptionNotFoundException();
+
+            var beneficiaryIds = request.Beneficiaries.Select(x => x.LongIdentifierForType<Beneficiary>()).ToList();
+            var beneficiaries = await db.Beneficiaries.Where(x => beneficiaryIds.Contains(x.Id)).ToListAsync();
+
+            if (beneficiaryIds.Count != beneficiaries.Count)
+            {
+                throw new BeneficiaryNotFoundException();
+            }
+
+            var results = new List<AddingFundTransactionForSubscriptionByBeneficiaryItem>();
+
+            foreach (var item in beneficiaryIds)
+            {
+                var transactionCount = await db.Transactions.OfType<SubscriptionAddingFundTransaction>().Where(x => x.BeneficiaryId == item && x.SubscriptionType.SubscriptionId == subscriptionId).CountAsync();
+                
+                results.Add(new AddingFundTransactionForSubscriptionByBeneficiaryItem()
+                {
+                    BeneficiaryId = Id.New<Beneficiary>(item),
+                    Count = transactionCount
+                });
+            }
+
+            return new AddingFundTransactionForSubscriptionByBeneficiaryPayload()
+            {
+                Beneficiaries = results
+            };
+        }
+
+        public class Input : HaveSubscriptionId, IRequest<AddingFundTransactionForSubscriptionByBeneficiaryPayload>
+        {
+            public IEnumerable<Id> Beneficiaries { get; set; }
+        }
+
+        public class AddingFundTransactionForSubscriptionByBeneficiaryPayload
+        {
+            public IEnumerable<AddingFundTransactionForSubscriptionByBeneficiaryItem> Beneficiaries { get; set; }
+        }
+
+        public class AddingFundTransactionForSubscriptionByBeneficiaryItem
+        {
+            public Id BeneficiaryId { get; set; }
+            public int Count { get; set; }
+        }
+
+        public class SubscriptionNotFoundException : RequestValidationException { }
+        public class BeneficiaryNotFoundException : RequestValidationException { }
+    }
+}

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetSubscriptionTransactionsByBeneficiaryAndSubscriptionId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetSubscriptionTransactionsByBeneficiaryAndSubscriptionId.cs
@@ -26,7 +26,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         {
             var transactions = await db.Transactions.OfType<SubscriptionAddingFundTransaction>()
                 .Include(x => x.SubscriptionType)
-                .Where(x => x.BeneficiaryId == request.Group && x.Status != DbModel.Enums.FundTransactionStatus.Unassigned && request.Ids.Contains(x.SubscriptionType.SubscriptionId)).ToListAsync();
+                .Where(x => x.BeneficiaryId == request.Group && request.Ids.Contains(x.SubscriptionType.SubscriptionId)).ToListAsync();
 
             return transactions.ToLookup(x => x.SubscriptionType.SubscriptionId, x => new TransactionGraphType(x));
         }

--- a/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
@@ -692,10 +692,41 @@ const amountThatWillBeAllocatedModalMoneyFormat = computed(() => {
   return amount !== 0 ? getMoneyFormat(amount) : "0$";
 });
 
+const { result: resultForecastAddingFundTransactionForSubscriptionByBeneficiary } = useQuery(
+  gql`
+    query ForecastAddingFundTransactionForSubscriptionByBeneficiary($subscriptionId: ID!, $beneficiaryIds: [ID!]) {
+      forecastAddingFundTransactionForSubscriptionByBeneficiary(
+        subscriptionId: $subscriptionId
+        beneficiaryIds: $beneficiaryIds
+      ) {
+        beneficiaries {
+          beneficiaryId
+          count
+        }
+      }
+    }
+  `,
+  ForecastAddingFundTransactionForSubscriptionByBeneficiaryVariables,
+  () => ({
+    enabled: selectedSubscription.value !== null && selectedBeneficiaries.value.length > 0
+  })
+);
+
+function ForecastAddingFundTransactionForSubscriptionByBeneficiaryVariables() {
+  return {
+    subscriptionId: selectedSubscription.value,
+    beneficiaryIds: selectedBeneficiaries.value.map((x) => x.id)
+  };
+}
+
 const amountThatWillBeAllocated = computed(() => {
   if (selectedSubscription.value === null) return 0;
+  if (resultForecastAddingFundTransactionForSubscriptionByBeneficiary.value === undefined) return 0;
 
   var selectedSubscriptionData = subscriptions.value.find((x) => x.value === selectedSubscription.value);
+  var subscriptionPaymentRemaining = selectedSubscriptionData.isSubscriptionPaymentBasedCardUsage
+    ? Math.min(selectedSubscriptionData.paymentRemaining, selectedSubscriptionData.maxNumberOfPayments)
+    : selectedSubscriptionData.paymentRemaining;
 
   var amount = 0;
 
@@ -704,12 +735,24 @@ const amountThatWillBeAllocated = computed(() => {
       .filter((y) => y.beneficiaryType.id === x.beneficiaryType.id)
       .reduce((accumulator, type) => accumulator + type.amount, 0);
 
-    var paymentRemaining = selectedSubscriptionData.isSubscriptionPaymentBasedCardUsage
-      ? Math.min(selectedSubscriptionData.paymentRemaining, selectedSubscriptionData.maxNumberOfPayments)
-      : selectedSubscriptionData.paymentRemaining;
+    var paymentRemaining = subscriptionPaymentRemaining;
+    var beneficiaryTransactionCount =
+      resultForecastAddingFundTransactionForSubscriptionByBeneficiary.value.forecastAddingFundTransactionForSubscriptionByBeneficiary.beneficiaries.find(
+        (y) => y.beneficiaryId === x.id
+      )?.count ?? 0;
 
-    if (replicatePaymentOnAttribution.value && x.card) {
-      paymentRemaining++;
+    if (selectedSubscriptionData.isSubscriptionPaymentBasedCardUsage) {
+      paymentRemaining = Math.min(paymentRemaining, selectedSubscriptionData.maxNumberOfPayments - beneficiaryTransactionCount);
+    }
+
+    if (replicatePaymentOnAttribution.value && x.card && paymentRemaining > 0) {
+      if (selectedSubscriptionData.isSubscriptionPaymentBasedCardUsage) {
+        if (selectedSubscriptionData.maxNumberOfPayments - beneficiaryTransactionCount > subscriptionPaymentRemaining) {
+          paymentRemaining++;
+        }
+      } else {
+        paymentRemaining++;
+      }
     }
 
     if (selectedSubscriptionData.isSubscriptionPaymentBasedCardUsage) {


### PR DESCRIPTION
[Réactiver le versement manqué pour les abonnements avec un nombre maximum de versement (exemple Roots)](https://sigmund-ca.atlassian.net/browse/CRCL-2373)

Maintenant, il est impossible d'ajouter plus de versement que le maximum d'un abonnement même si on enlève un participant d'un abonnement et qu'on le rajoute par la suite.