### PR TITLE
Fix issue with cash-register select disabled when marketId is already set

### DIFF
--- a/Sig.App.Frontend/src/views/transaction/SelectMarket.vue
+++ b/Sig.App.Frontend/src/views/transaction/SelectMarket.vue
@@ -23,7 +23,7 @@
       "market-disabled-label": "{market} est désactivé"
     }
   }
-  </i18n>
+</i18n>
 
 <template>
   <div>
@@ -74,7 +74,7 @@
 
 <script setup>
 import gql from "graphql-tag";
-import { computed, defineProps, defineEmits, ref } from "vue";
+import { computed, defineProps, defineEmits, ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { string, object } from "yup";
 import { useQuery, useResult } from "@vue/apollo-composable";
@@ -100,6 +100,10 @@ const props = defineProps({
     type: String,
     default: ""
   }
+});
+
+onMounted(() => {
+  selectedMarket.value = props.marketId;
 });
 
 const initialValues = computed(() => {


### PR DESCRIPTION
[Bogue en créant une transaction au nom d'un commerce : champs de la caisse désactivé #192](https://sigmund-ca.atlassian.net/browse/CRCL-2364)