### PR TITLE
Add the possibility to extend subscription for specific beneficiary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ ClientApp
 npm-debug.log
 
 nCrunchTemp*
+
+// Come from Claude-Code test
+Sig.App.Backend/binTestOutput/*
+Sig.App.BackendTests/binTestOutput/*

--- a/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
+++ b/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
@@ -123,8 +123,7 @@ namespace Sig.App.Backend.BackgroundJobs
             {
                 foreach (var subscriptionBeneficiary in subscription.Beneficiaries)
                 {
-                    var beneficiary = subscriptionBeneficiary.Beneficiary;
-                    CreateTransaction(beneficiary, subscriptionBeneficiary.BeneficiaryType, subscription);
+                    CreateTransaction(subscriptionBeneficiary);
                 }
             }
 
@@ -229,24 +228,27 @@ namespace Sig.App.Backend.BackgroundJobs
             var beneficiaryIdLong = beneficiaryId.LongIdentifierForType<Beneficiary>();
             var subscriptionIdLong = subscriptionId.LongIdentifierForType<Subscription>();
 
-            var subscription = await db.Subscriptions
-                .Include(x => x.BudgetAllowances)
-                .AsSplitQuery().Include(x => x.Types).ThenInclude(x => x.ProductGroup)
-                .Where(x => x.Id == subscriptionIdLong).FirstAsync();
+            var subscriptionBeneficiary = await db.SubscriptionBeneficiaries
+                .Include(x => x.Subscription).ThenInclude(x => x.BudgetAllowances)
+                .AsSplitQuery().Include(x => x.Subscription.Types).ThenInclude(x => x.ProductGroup)
+                .Include(x => x.Beneficiary).ThenInclude(x => x.Card).ThenInclude(x => x.Transactions)
+                .Include(x => x.Beneficiary).ThenInclude(x => x.Card).ThenInclude(x => x.Funds)
+                .Include(x => x.Beneficiary).ThenInclude(x => x.Organization).ThenInclude(x => x.Project)
+                .Where(x => x.SubscriptionId == subscriptionIdLong && x.BeneficiaryId == beneficiaryIdLong && x.BeneficiaryTypeId == beneficiaryType.Id)
+                .FirstOrDefaultAsync();
 
-            var beneficiary = await db.Beneficiaries
-                .Include(x => x.Card).ThenInclude(x => x.Transactions)
-                .Include(x => x.Card).ThenInclude(x => x.Funds)
-                .Include(x => x.Organization).ThenInclude(x => x.Project)
-                .Where(x => x.Id== beneficiaryIdLong)
-                .FirstAsync();
+            if (subscriptionBeneficiary == null) return;
 
-            CreateTransaction(beneficiary, beneficiaryType, subscription, initiatedBy);
+            CreateTransaction(subscriptionBeneficiary, initiatedBy);
             await db.SaveChangesAsync();
         }
 
-        private void CreateTransaction(Beneficiary beneficiary, BeneficiaryType beneficiaryType, Subscription subscription, InitiatedBy initiatedBy = null)
+        private void CreateTransaction(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)
         {
+            var subscription = subscriptionBeneficiary.Subscription;
+            var beneficiary = subscriptionBeneficiary.Beneficiary;
+            var beneficiaryType = subscriptionBeneficiary.BeneficiaryType;
+
             var subscriptionTypes = subscription.Types.Where(x => x.BeneficiaryTypeId == beneficiaryType.Id);
 
             if (beneficiary.Card != null)
@@ -257,12 +259,13 @@ namespace Sig.App.Backend.BackgroundJobs
                     var subscriptionAddedFundCount = beneficiary.Card.Transactions.OfType<SubscriptionAddingFundTransaction>().Count(x => subscriptionTypes.Any(y => y.Id == x.SubscriptionTypeId));
 
                     // The beneficiary already received all the funds
-                    if (subscription.MaxNumberOfPayments.Value == subscriptionAddedFundCount * subscriptionTypes.Count()) return;
+                    var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
+                    if (maxNumberOfPayments == subscriptionAddedFundCount * subscriptionTypes.Count()) return;
 
                     var previousPaymentDateTime = SubscriptionHelper.GetPreviousPaymentDateTime(clock, subscription.MonthlyPaymentMoment);
                     if (subscriptionAddedFundCount != 0 && !beneficiary.Card.Transactions.Where(x => x is PaymentTransaction).Any(x => x.CreatedAtUtc >= previousPaymentDateTime))
                     {
-                        if (subscription.MaxNumberOfPayments - subscriptionAddedFundCount >= subscription.GetPaymentRemaining(clock))
+                        if (maxNumberOfPayments - subscriptionAddedFundCount >= subscriptionBeneficiary.GetPaymentRemaining(clock))
                         {
                             RefundBudgetAllowance(subscription, beneficiary, subscriptionTypes);
                         }
@@ -351,7 +354,8 @@ namespace Sig.App.Backend.BackgroundJobs
             {
                 if (subscription.IsSubscriptionPaymentBasedCardUsage)
                 {
-                    if (subscription.MaxNumberOfPayments >= subscription.GetPaymentRemaining(clock))
+                    var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
+                    if (maxNumberOfPayments >= subscriptionBeneficiary.GetPaymentRemaining(clock))
                     {
                         RefundBudgetAllowance(subscription, beneficiary, subscriptionTypes);
                     }

--- a/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
+++ b/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
@@ -115,8 +115,9 @@ namespace Sig.App.Backend.BackgroundJobs
                 .Include(x => x.Beneficiaries).ThenInclude(x => x.Beneficiary).ThenInclude(x => x.Card).ThenInclude(x => x.Funds)
                 .Include(x => x.Beneficiaries).ThenInclude(x => x.Beneficiary).ThenInclude(x => x.Organization).ThenInclude(x => x.Project)
                 .Include(x => x.Beneficiaries).ThenInclude(x => x.BeneficiaryType)
+                .AsSplitQuery()
                 .Include(x => x.BudgetAllowances)
-                .AsSplitQuery().Include(x => x.Types).ThenInclude(x => x.ProductGroup)
+                .Include(x => x.Types).ThenInclude(x => x.ProductGroup)
                 .Where(x => x.StartDate <= today && x.EndDate >= today && monthlyPaymentMoment.Contains(x.MonthlyPaymentMoment)).ToListAsync();
 
             foreach (var subscription in activeSubscriptions)
@@ -257,9 +258,9 @@ namespace Sig.App.Backend.BackgroundJobs
                 if (subscription.IsSubscriptionPaymentBasedCardUsage && initiatedBy == null)
                 {
                     var subscriptionAddedFundCount = beneficiary.Card.Transactions.OfType<SubscriptionAddingFundTransaction>().Count(x => subscriptionTypes.Any(y => y.Id == x.SubscriptionTypeId));
+                    var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
 
                     // The beneficiary already received all the funds
-                    var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
                     if (maxNumberOfPayments == subscriptionAddedFundCount * subscriptionTypes.Count()) return;
 
                     var previousPaymentDateTime = SubscriptionHelper.GetPreviousPaymentDateTime(clock, subscription.MonthlyPaymentMoment);

--- a/Sig.App.Backend/BackgroundJobs/DeleteBeneficiary.cs
+++ b/Sig.App.Backend/BackgroundJobs/DeleteBeneficiary.cs
@@ -83,7 +83,7 @@ namespace Sig.App.Backend.BackgroundJobs
 
         private DateTime ExpirationDate(Beneficiary beneficiary)
         {
-            if (beneficiary.Subscriptions.Where(x => x.Subscription.GetPaymentRemaining(clock) > 0 && x.Subscription.GetExpirationDate(clock) > DateTime.UtcNow).Any())
+            if (beneficiary.Subscriptions.Where(x => x.GetPaymentRemaining(clock) > 0 && x.Subscription.GetExpirationDate(clock) > DateTime.UtcNow).Any())
             {
                 return DateTime.MaxValue;
             }

--- a/Sig.App.Backend/DbModel/Entities/Subscriptions/SubscriptionBeneficiary.cs
+++ b/Sig.App.Backend/DbModel/Entities/Subscriptions/SubscriptionBeneficiary.cs
@@ -10,6 +10,8 @@ namespace Sig.App.Backend.DbModel.Entities.Subscriptions
         public long? BeneficiaryTypeId { get; set; }
         public long? BudgetAllowanceId { get; set; }
 
+        public int? MaxNumberOfPaymentsOverride { get; set; }
+
         public Subscription Subscription { get; set; }
         public Beneficiary Beneficiary { get; set; }
         public BeneficiaryType BeneficiaryType { get; set; }

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
@@ -17,12 +17,14 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         private readonly Beneficiary beneficiary;
         private readonly Subscription subscription;
         private readonly BeneficiaryType beneficiaryType;
+        private readonly SubscriptionBeneficiary subscriptionBeneficiary;
 
-        public BeneficiarySubscriptionTypeGraphType(Beneficiary beneficiary, Subscription subscription, BeneficiaryType beneficiaryType)
+        public BeneficiarySubscriptionTypeGraphType(Beneficiary beneficiary, Subscription subscription, BeneficiaryType beneficiaryType, SubscriptionBeneficiary subscriptionBeneficiary)
         {
             this.beneficiary = beneficiary;
             this.subscription = subscription;
             this.beneficiaryType = beneficiaryType;
+            this.subscriptionBeneficiary = subscriptionBeneficiary;
         }
 
         public IDataLoaderResult<IBeneficiaryGraphType> Beneficiary(IAppUserContext ctx)
@@ -53,22 +55,21 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         public async Task<int> PaymentRemaining(IAppUserContext ctx, [Inject] IClock clock)
         {
             var transactions = await ctx.DataLoader.LoadSubscriptionTransactionsByBeneficiaryAndSubscriptionId(beneficiary.Id, subscription.Id).GetResultAsync();
-            var subscriptionTotalPayment = subscription.GetTotalPayment();
-            var subscriptionPaymentRemaining = subscription.GetPaymentRemaining(clock);
-            var maxNumberOfPayments = subscription.MaxNumberOfPayments.HasValue ? subscription.MaxNumberOfPayments.Value : subscriptionTotalPayment;
+            var subscriptionPaymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
+            var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
 
             return Math.Min(maxNumberOfPayments - transactions.Count(), subscriptionPaymentRemaining);
         }
 
         public int MaxNumberOfPayments()
         {
-            return subscription.MaxNumberOfPayments.HasValue ? subscription.MaxNumberOfPayments.Value : subscription.GetTotalPayment();
+            return subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
         }
 
         public async Task<bool> HasMissedPayment(IAppUserContext ctx, [Inject] IClock clock) {
             var transactions = await ctx.DataLoader.LoadSubscriptionTransactionsByBeneficiaryAndSubscriptionId(beneficiary.Id, subscription.Id).GetResultAsync();
-            var subscriptionTotalPayment = subscription.GetTotalPayment();
-            var subscriptionPaymentRemaining = subscription.GetPaymentRemaining(clock);
+            var subscriptionTotalPayment = subscriptionBeneficiary.GetTotalPayment();
+            var subscriptionPaymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
 
             if (subscription.MaxNumberOfPayments.HasValue)
             {

--- a/Sig.App.Backend/Gql/Schema/Mutation.cs
+++ b/Sig.App.Backend/Gql/Schema/Mutation.cs
@@ -950,6 +950,15 @@ namespace Sig.App.Backend.Gql.Schema
             return mediator.Send(input.Value);
         }
 
+        [AnnotateErrorCodes(typeof(ChangeBeneficiarySubscriptionMaxNumberOfPayments))]
+        public static Task<ChangeBeneficiarySubscriptionMaxNumberOfPayments.Payload> ChangeBeneficiarySubscriptionMaxNumberOfPayments(
+            this GqlMutation _,
+            [Inject] IMediator mediator,
+            NonNull<ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input> input)
+        {
+            return mediator.Send(input.Value);
+        }
+
         public static Task<AddMissingPayment.Payload> AddMissingPayment(
             this GqlMutation _,
             [Inject] IMediator mediator,

--- a/Sig.App.Backend/Helpers/SubscriptionHelper.cs
+++ b/Sig.App.Backend/Helpers/SubscriptionHelper.cs
@@ -7,7 +7,26 @@ namespace Sig.App.Backend.Helpers
 {
     public static class SubscriptionHelper
     {
+        public static int GetEffectiveMaxNumberOfPayments(this SubscriptionBeneficiary subscriptionBeneficiary)
+        {
+            return subscriptionBeneficiary.MaxNumberOfPaymentsOverride
+                ?? subscriptionBeneficiary.Subscription.MaxNumberOfPayments
+                ?? subscriptionBeneficiary.GetTotalPayment();
+        }
+
+        public static int GetPaymentRemaining(this SubscriptionBeneficiary subscriptionBeneficiary, IClock clock)
+        {
+            var cardPaymentRemaining = GetCardPaymentRemaining(subscriptionBeneficiary.Subscription, clock);
+            return Math.Max(0, subscriptionBeneficiary.Subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(cardPaymentRemaining, subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments()) : cardPaymentRemaining);
+        }
+
         public static int GetPaymentRemaining(this Subscription subscription, IClock clock)
+        {
+            var cardPaymentRemaining = GetCardPaymentRemaining(subscription, clock);
+            return Math.Max(0, subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(cardPaymentRemaining, subscription.MaxNumberOfPayments.Value) : cardPaymentRemaining);
+        }
+
+        private static int GetCardPaymentRemaining(this Subscription subscription, IClock clock)
         {
             var cardPaymentRemaining = 0;
             var today = clock
@@ -46,13 +65,25 @@ namespace Sig.App.Backend.Helpers
 
             if (needExtraDay) cardPaymentRemaining++;
 
-            return Math.Max(0, subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(cardPaymentRemaining, subscription.MaxNumberOfPayments.Value) : cardPaymentRemaining);
+            return cardPaymentRemaining;
         }
 
         public static int GetTotalPayment(this Subscription subscription)
         {
-            var cardPaymentRemaining = 0;
-            
+            var totalPayment = GetTotalPaymentBySubscription(subscription);
+            return subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(subscription.MaxNumberOfPayments.Value, totalPayment) : totalPayment;
+        }
+
+        public static int GetTotalPayment(this SubscriptionBeneficiary subscriptionBeneficiary)
+        {
+            var totalPayment = GetTotalPaymentBySubscription(subscriptionBeneficiary.Subscription);
+            return subscriptionBeneficiary.Subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments(), totalPayment) : totalPayment;
+        }
+
+        private static int GetTotalPaymentBySubscription(Subscription subscription)
+        {
+            var totalPayment = 0;
+
             var startDate = subscription.StartDate;
             var endDate = subscription.EndDate;
 
@@ -61,8 +92,8 @@ namespace Sig.App.Backend.Helpers
             {
                 int monthsApart = 12 * (endDate.Year - startDate.Year) + endDate.Month - startDate.Month;
 
-                cardPaymentRemaining += monthsApart;
-                if (startDate.Day == 1) cardPaymentRemaining++;
+                totalPayment += monthsApart;
+                if (startDate.Day == 1) totalPayment++;
             }
 
             if (subscription.MonthlyPaymentMoment == SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth ||
@@ -78,12 +109,12 @@ namespace Sig.App.Backend.Helpers
                     monthsApart--;
                 }
 
-                cardPaymentRemaining += monthsApart;
+                totalPayment += monthsApart;
 
-                if (startDate.Day == 15) cardPaymentRemaining++;
+                if (startDate.Day == 15) totalPayment++;
             }
 
-            return subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(subscription.MaxNumberOfPayments.Value, cardPaymentRemaining) : cardPaymentRemaining;
+            return totalPayment;
         }
 
         public static DateTime GetFirstPaymentDateTime(this Subscription subscription, IClock clock)

--- a/Sig.App.Backend/Helpers/SubscriptionHelper.cs
+++ b/Sig.App.Backend/Helpers/SubscriptionHelper.cs
@@ -17,7 +17,11 @@ namespace Sig.App.Backend.Helpers
         public static int GetPaymentRemaining(this SubscriptionBeneficiary subscriptionBeneficiary, IClock clock)
         {
             var cardPaymentRemaining = GetCardPaymentRemaining(subscriptionBeneficiary.Subscription, clock);
-            return Math.Max(0, subscriptionBeneficiary.Subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(cardPaymentRemaining, subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments()) : cardPaymentRemaining);
+            if (subscriptionBeneficiary.Subscription.IsSubscriptionPaymentBasedCardUsage)
+            {
+                cardPaymentRemaining = Math.Min(cardPaymentRemaining, subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments());
+            }
+            return Math.Max(0, cardPaymentRemaining);
         }
 
         public static int GetPaymentRemaining(this Subscription subscription, IClock clock)

--- a/Sig.App.Backend/Migrations/20260326193725_AddMaxNumberOfPaymentsOverride.Designer.cs
+++ b/Sig.App.Backend/Migrations/20260326193725_AddMaxNumberOfPaymentsOverride.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sig.App.Backend.DbModel;
 
@@ -11,9 +12,11 @@ using Sig.App.Backend.DbModel;
 namespace Sig.App.Backend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260326193725_AddMaxNumberOfPaymentsOverride")]
+    partial class AddMaxNumberOfPaymentsOverride
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sig.App.Backend/Migrations/20260326193725_AddMaxNumberOfPaymentsOverride.cs
+++ b/Sig.App.Backend/Migrations/20260326193725_AddMaxNumberOfPaymentsOverride.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sig.App.Backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaxNumberOfPaymentsOverride : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxNumberOfPaymentsOverride",
+                table: "SubscriptionBeneficiaries",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxNumberOfPaymentsOverride",
+                table: "SubscriptionBeneficiaries");
+        }
+    }
+}

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
@@ -66,8 +66,11 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                 var newPaymentAmount = GetAmountPayment(subscriptionBeneficiary.Subscription, beneficiary.BeneficiaryTypeId.Value);
 
                 var paymentReceived = beneficiaryTransactions.Where(x => x.SubscriptionType.SubscriptionId == subscriptionBeneficiary.SubscriptionId).Count();
-                var paymentRemaining = subscriptionBeneficiary.Subscription.GetPaymentRemaining(clock);
-                var numberOfPaymentToReceive = Math.Min(subscriptionBeneficiary.Subscription.MaxNumberOfPayments.HasValue ? subscriptionBeneficiary.Subscription.MaxNumberOfPayments.Value - paymentReceived : paymentRemaining, paymentRemaining);
+                var paymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
+                var cap = subscriptionBeneficiary.MaxNumberOfPaymentsOverride.HasValue || subscriptionBeneficiary.Subscription.MaxNumberOfPayments.HasValue
+                    ? subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments() - paymentReceived
+                    : paymentRemaining;
+                var numberOfPaymentToReceive = Math.Min(cap, paymentRemaining);
 
                 if (subscriptionBeneficiary.BudgetAllowance.AvailableFund + (previousPaymentAmount - newPaymentAmount) * numberOfPaymentToReceive > 0)
                 {

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
@@ -48,9 +48,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             var subscription = subscriptionBeneficiary.Subscription;
-            var currentMax = subscriptionBeneficiary.MaxNumberOfPaymentsOverride
-                ?? subscription.MaxNumberOfPayments
-                ?? subscriptionBeneficiary.GetTotalPayment();
+            var currentMax = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
 
             if (request.MaxNumberOfPayments <= currentMax)
             {

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
@@ -1,0 +1,99 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sig.App.Backend.DbModel;
+using Sig.App.Backend.DbModel.Entities.Beneficiaries;
+using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.Extensions;
+using Sig.App.Backend.Gql.Bases;
+using Sig.App.Backend.Gql.Schema.GraphTypes;
+using Sig.App.Backend.Helpers;
+using Sig.App.Backend.Plugins.GraphQL;
+using Sig.App.Backend.Plugins.MediatR;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
+{
+    public class ChangeBeneficiarySubscriptionMaxNumberOfPayments : IRequestHandler<ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input, ChangeBeneficiarySubscriptionMaxNumberOfPayments.Payload>
+    {
+        private readonly ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger;
+        private readonly AppDbContext db;
+
+        public ChangeBeneficiarySubscriptionMaxNumberOfPayments(ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger, AppDbContext db)
+        {
+            this.logger = logger;
+            this.db = db;
+        }
+
+        public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
+        {
+            logger.LogInformation($"[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments({request.BeneficiaryId}, {request.SubscriptionId}, {request.MaxNumberOfPayments})");
+
+            var beneficiaryId = request.BeneficiaryId.LongIdentifierForType<Beneficiary>();
+            var subscriptionId = request.SubscriptionId.LongIdentifierForType<Subscription>();
+
+            var subscriptionBeneficiary = await db.SubscriptionBeneficiaries
+                .Include(x => x.Subscription).ThenInclude(x => x.Types)
+                .Include(x => x.BudgetAllowance)
+                .Include(x => x.Beneficiary)
+                .Where(x => x.BeneficiaryId == beneficiaryId && x.SubscriptionId == subscriptionId)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (subscriptionBeneficiary == null)
+            {
+                logger.LogWarning("[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - BeneficiaryNotInSubscriptionException");
+                throw new BeneficiaryNotInSubscriptionException();
+            }
+
+            var subscription = subscriptionBeneficiary.Subscription;
+            var currentMax = subscriptionBeneficiary.MaxNumberOfPaymentsOverride
+                ?? subscription.MaxNumberOfPayments
+                ?? subscriptionBeneficiary.GetTotalPayment();
+
+            if (request.MaxNumberOfPayments <= currentMax)
+            {
+                logger.LogWarning("[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - MaxNumberOfPaymentsMustBeGreaterThanCurrentException");
+                throw new MaxNumberOfPaymentsMustBeGreaterThanCurrentException();
+            }
+
+            var additionalPayments = request.MaxNumberOfPayments - currentMax;
+            var amountPerPayment = subscription.Types
+                .Where(x => x.BeneficiaryTypeId == subscriptionBeneficiary.BeneficiaryTypeId)
+                .Sum(x => x.Amount);
+            var totalCost = additionalPayments * amountPerPayment;
+
+            if (subscriptionBeneficiary.BudgetAllowance.AvailableFund < totalCost)
+            {
+                logger.LogWarning("[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - NotEnoughBudgetAllowanceException");
+                throw new NotEnoughBudgetAllowanceException();
+            }
+
+            subscriptionBeneficiary.BudgetAllowance.AvailableFund -= totalCost;
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = request.MaxNumberOfPayments;
+
+            await db.SaveChangesAsync(cancellationToken);
+
+            logger.LogInformation($"[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - MaxNumberOfPaymentsOverride set to {request.MaxNumberOfPayments} for beneficiary {beneficiaryId} in subscription {subscriptionId}");
+
+            return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary) };
+        }
+
+        [MutationInput]
+        public class Input : HaveSubscriptionIdAndBeneficiaryId, IRequest<Payload>
+        {
+            public int MaxNumberOfPayments { get; set; }
+        }
+
+        [MutationPayload]
+        public class Payload
+        {
+            public BeneficiaryGraphType Beneficiary { get; set; }
+        }
+
+        public class BeneficiaryNotInSubscriptionException : RequestValidationException { }
+        public class MaxNumberOfPaymentsMustBeGreaterThanCurrentException : RequestValidationException { }
+        public class NotEnoughBudgetAllowanceException : RequestValidationException { }
+    }
+}

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscription.cs
@@ -43,6 +43,8 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             var subscriptionId = request.SubscriptionId.LongIdentifierForType<Subscription>();
             var subscription = await db.Subscriptions.Include(x => x.Types).ThenInclude(x => x.ProductGroup)
                 .Include(x => x.Beneficiaries).ThenInclude(x => x.BudgetAllowance)
+                .Include(x => x.Beneficiaries).ThenInclude(x => x.Beneficiary)
+                .Include(x => x.Beneficiaries).ThenInclude(x => x.BeneficiaryType)
                 .FirstOrDefaultAsync(x => x.Id == subscriptionId, cancellationToken);
 
             if (subscription == null)
@@ -80,7 +82,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             beneficiary.Subscriptions.Remove(subscriptionBeneficiary);
 
-            var paymentsRemaining = subscription.GetPaymentRemaining(clock);
+            var paymentsRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
             var subscriptionTypes = subscription.Types.Where(x => x.BeneficiaryTypeId == subscriptionBeneficiary.BeneficiaryTypeId).ToList();
             var totalRefund = paymentsRemaining * subscriptionTypes.Sum(x => x.Amount);
             
@@ -92,7 +94,8 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                     subscriptionAddingFundTransactionCount = beneficiaryTransactions.OfType<SubscriptionAddingFundTransaction>().Where(x => x.SubscriptionType.SubscriptionId == subscription.Id).Count();
                 }
 
-                paymentsRemaining = Math.Max(0, Math.Min(paymentsRemaining, subscription.MaxNumberOfPayments.Value - subscriptionAddingFundTransactionCount));
+                var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
+                paymentsRemaining = Math.Max(0, Math.Min(paymentsRemaining, maxNumberOfPayments - subscriptionAddingFundTransactionCount));
                 totalRefund = paymentsRemaining * subscriptionTypes.Sum(x => x.Amount);
             }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -108,16 +108,14 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                 .Include(x => x.SubscriptionType)
                 .Where(x => x.BeneficiaryId == beneficiary.Id && x.SubscriptionType.SubscriptionId == subscription.Id).ToListAsync();
 
-            var subscriptionTotalPayment = subscription.GetTotalPayment();
-            var subscriptionPaymentRemaining = subscription.GetPaymentRemaining(clock);
+            var subscriptionTotalPayment = subscriptionBeneficiary.GetTotalPayment();
+            var subscriptionPaymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
 
-            if (subscription.MaxNumberOfPayments.HasValue)
+            if ((subscriptionBeneficiary.MaxNumberOfPaymentsOverride.HasValue || subscription.MaxNumberOfPayments.HasValue)
+                && transactions.Count() >= subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments())
             {
-                if (transactions.Count() == subscription.MaxNumberOfPayments)
-                {
-                    logger.LogWarning("[Mutation] AddMissingPayment - SubscriptionDontHaveMissedPaymentException");
-                    throw new SubscriptionDontHaveMissedPaymentException();
-                }
+                logger.LogWarning("[Mutation] AddMissingPayment - SubscriptionDontHaveMissedPaymentException");
+                throw new SubscriptionDontHaveMissedPaymentException();
             }
             else if (transactions.Count() >= subscriptionTotalPayment - subscriptionPaymentRemaining)
             {
@@ -125,7 +123,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                 throw new SubscriptionDontHaveMissedPaymentException();
             }
 
-            var maxNumberOfPayments = subscription.MaxNumberOfPayments.HasValue ? subscription.MaxNumberOfPayments.Value : subscriptionTotalPayment;
+            var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
             var isBudgetAllowanceAlreadyAllocated = maxNumberOfPayments - transactions.Count <= Math.Min(maxNumberOfPayments - transactions.Count(), subscriptionPaymentRemaining);
             if (!isBudgetAllowanceAlreadyAllocated)
             {

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
@@ -109,16 +109,14 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                     .Include(x => x.SubscriptionType)
                     .Where(x => x.BeneficiaryId == beneficiary.Id && x.SubscriptionType.SubscriptionId == subscription.Id).ToListAsync();
 
-                var subscriptionTotalPayment = subscription.GetTotalPayment();
-                var subscriptionPaymentRemaining = subscription.GetPaymentRemaining(clock);
+                var subscriptionTotalPayment = subscriptionBeneficiary.GetTotalPayment();
+                var subscriptionPaymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
 
-                if (subscription.MaxNumberOfPayments.HasValue)
+                if ((subscriptionBeneficiary.MaxNumberOfPaymentsOverride.HasValue || subscription.MaxNumberOfPayments.HasValue)
+                    && transactions.Count() >= subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments())
                 {
-                    if (transactions.Count() == subscription.MaxNumberOfPayments)
-                    {
-                        logger.LogWarning("[Mutation] AddMissingPayment - SubscriptionDontHaveMissedPaymentException");
-                        throw new SubscriptionDontHaveMissedPaymentException();
-                    }
+                    logger.LogWarning("[Mutation] AddMissingPayment - SubscriptionDontHaveMissedPaymentException");
+                    throw new SubscriptionDontHaveMissedPaymentException();
                 }
                 else if (transactions.Count() >= subscriptionTotalPayment - subscriptionPaymentRemaining)
                 {

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiarySubscription.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiarySubscription.cs
@@ -21,7 +21,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public override async Task<ILookup<long, BeneficiarySubscriptionTypeGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
             var results = await db.SubscriptionBeneficiaries.Include(x => x.Subscription).Include(x => x.Beneficiary).Include(x => x.BeneficiaryType).Where(x => request.Ids.Contains(x.BeneficiaryId)).ToListAsync();
-            return results.ToLookup(x => x.BeneficiaryId, x => new BeneficiarySubscriptionTypeGraphType(x.Beneficiary, x.Subscription, x.BeneficiaryType));
+            return results.ToLookup(x => x.BeneficiaryId, x => new BeneficiarySubscriptionTypeGraphType(x.Beneficiary, x.Subscription, x.BeneficiaryType, x));
         }
     }
 }

--- a/Sig.App.BackendTests/BackgroundJobs/AddingFundToCardTest.cs
+++ b/Sig.App.BackendTests/BackgroundJobs/AddingFundToCardTest.cs
@@ -31,6 +31,7 @@ namespace Sig.App.BackendTests.BackgroundJobs
         private readonly AddingFundToCard job;
         private readonly BeneficiaryType beneficiaryType;
         private readonly ProductGroup productGroup;
+        private readonly SubscriptionBeneficiary subscriptionBeneficiary;
 
         public AddingFundToCardTest()
         {
@@ -143,19 +144,21 @@ namespace Sig.App.BackendTests.BackgroundJobs
             DbContext.Projects.Add(project);
 
             DbContext.SaveChanges();
-            
+
+            subscriptionBeneficiary = new SubscriptionBeneficiary()
+            {
+                Beneficiary = beneficiary,
+                Subscription = subscription,
+                BeneficiaryType = beneficiary.BeneficiaryType
+            };
+
             subscription.BudgetAllowances = new List<BudgetAllowance>()
             {
                 new BudgetAllowance()
                 {
                     Beneficiaries = new List<SubscriptionBeneficiary>()
                     {
-                        new SubscriptionBeneficiary()
-                        {
-                            Beneficiary = beneficiary, 
-                            Subscription = subscription, 
-                            BeneficiaryType = beneficiary.BeneficiaryType
-                        }
+                        subscriptionBeneficiary
                     },
                     Organization = organization,
                     AvailableFund = 2500,
@@ -406,6 +409,105 @@ namespace Sig.App.BackendTests.BackgroundJobs
             var transactionLog = await DbContext.TransactionLogs.FirstAsync(x =>
                 x.Discriminator == TransactionLogDiscriminator.SubscriptionAddingFundTransactionLog);
             transactionLog.TotalAmount.Should().Be(25);
+        }
+
+        [Fact]
+        public async Task AddFundIfParticipantHaveMaxNumberOfPaymentsOverride()
+        {
+            var today = Clock.GetCurrentInstant().ToDateTimeUtc();
+            Clock.Reset(Instant.FromUtc(today.Year, today.Month, 1, 0, 0));
+
+            var budgetAllowance = DbContext.BudgetAllowances.First();
+            var availableFundsInitially = budgetAllowance.AvailableFund;
+
+            subscription.IsSubscriptionPaymentBasedCardUsage = true;
+            subscription.MaxNumberOfPayments = 1;
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 2;
+
+            beneficiary.Card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                TransactionUniqueId = TransactionHelper.CreateTransactionUniqueId(),
+                Amount = 1,
+                Card = beneficiary.Card,
+                Beneficiary = beneficiary,
+                OrganizationId = beneficiary.OrganizationId,
+                CreatedAtUtc = today,
+                ExpirationDate = today.AddMonths(1),
+                SubscriptionType = subscription.Types.First(),
+                AvailableFund = 1,
+            });
+
+            beneficiary.Card.Transactions.Add(new PaymentTransaction()
+            {
+                TransactionUniqueId = TransactionHelper.CreateTransactionUniqueId(),
+                Amount = 1,
+                Card = beneficiary.Card,
+                Beneficiary = beneficiary,
+                OrganizationId = beneficiary.OrganizationId,
+                CreatedAtUtc = today
+            });
+
+            DbContext.SaveChanges();
+
+            await job.Run("AddFundToCard", new SubscriptionMonthlyPaymentMoment[1] { SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth });
+
+            var card = DbContext.Cards.Include(x => x.Funds).First();
+            card.Funds.First().Amount.Should().Be(45);
+
+            budgetAllowance = DbContext.BudgetAllowances.First();
+            var addedFunds = budgetAllowance.AvailableFund - availableFundsInitially;
+            addedFunds.Should().Be(0);
+
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync(x =>
+                x.Discriminator == TransactionLogDiscriminator.SubscriptionAddingFundTransactionLog);
+            transactionLog.TotalAmount.Should().Be(25);
+        }
+
+        [Fact]
+        public async Task DontAddFundIfParticipantHaveMaxNumberOfPaymentsOverrideAndMaxNumberOfTransaction()
+        {
+            var today = Clock.GetCurrentInstant().ToDateTimeUtc();
+            Clock.Reset(Instant.FromUtc(today.Year, today.Month, 1, 0, 0));
+
+            var budgetAllowance = DbContext.BudgetAllowances.First();
+            var availableFundsInitially = budgetAllowance.AvailableFund;
+
+            subscription.IsSubscriptionPaymentBasedCardUsage = true;
+            subscription.MaxNumberOfPayments = 1;
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 2;
+
+            beneficiary.Card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                TransactionUniqueId = TransactionHelper.CreateTransactionUniqueId(),
+                Amount = 1,
+                Card = beneficiary.Card,
+                Beneficiary = beneficiary,
+                OrganizationId = beneficiary.OrganizationId,
+                CreatedAtUtc = today,
+                ExpirationDate = today.AddMonths(1),
+                SubscriptionType = subscription.Types.First(),
+                AvailableFund = 1,
+            });
+
+            beneficiary.Card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                TransactionUniqueId = TransactionHelper.CreateTransactionUniqueId(),
+                Amount = 1,
+                Card = beneficiary.Card,
+                Beneficiary = beneficiary,
+                OrganizationId = beneficiary.OrganizationId,
+                CreatedAtUtc = today,
+                ExpirationDate = today.AddMonths(1),
+                SubscriptionType = subscription.Types.First(),
+                AvailableFund = 1,
+            });
+
+            DbContext.SaveChanges();
+
+            await job.Run("AddFundToCard", new SubscriptionMonthlyPaymentMoment[1] { SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth });
+
+            var card = DbContext.Cards.Include(x => x.Funds).First();
+            card.Funds.First().Amount.Should().Be(20);
         }
     }
 }

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscriptionTest.cs
@@ -334,6 +334,40 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         }
 
         [Fact]
+        public async Task AdjustBeneficiarySubscription_WithMaxNumberOfPaymentsOverride()
+        {
+            // Override=5 > MaxNumberOfPayments=4, so override drives the budget calculation
+            beneficiary.BeneficiaryType = beneficiaryType2;
+            var subscriptionBeneficiary3 = subscription3.Beneficiaries.First();
+            subscriptionBeneficiary3.MaxNumberOfPaymentsOverride = 5;
+            DbContext.SaveChanges();
+
+            var input = new AdjustBeneficiarySubscription.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionIds = new List<Id>()
+                {
+                    subscription3.GetIdentifier()
+                }
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var localBeneficiary = await DbContext.Beneficiaries
+                .Include(x => x.Subscriptions).ThenInclude(x => x.BudgetAllowance)
+                .Include(x => x.Subscriptions).ThenInclude(x => x.BeneficiaryType)
+                .FirstAsync();
+
+            var localSubscriptionBeneficiary = localBeneficiary.Subscriptions.First(x => x.SubscriptionId == subscription3.Id);
+            // paymentReceived=0, paymentRemaining>=5 (biweekly over ~3 months)
+            // numberOfPaymentToReceive = min(override=5, paymentRemaining) = 5
+            // previousAmount (type1)=25, newAmount (type2)=50
+            // budgetChange = (25-50)*5 = -125 → 600-125 = 475
+            localSubscriptionBeneficiary.BudgetAllowance.AvailableFund.Should().Be(475);
+            localSubscriptionBeneficiary.BeneficiaryTypeId.Should().Be(beneficiaryType2.Id);
+        }
+
+        [Fact]
         public async Task ThrowsIfBeneficiaryNotFound()
         {
             var input = new AdjustBeneficiarySubscription.Input()

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPaymentsTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPaymentsTest.cs
@@ -1,0 +1,260 @@
+using FluentAssertions;
+using GraphQL.Conventions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sig.App.Backend.DbModel.Entities.Beneficiaries;
+using Sig.App.Backend.DbModel.Entities.BudgetAllowances;
+using Sig.App.Backend.DbModel.Entities.Organizations;
+using Sig.App.Backend.DbModel.Entities.ProductGroups;
+using Sig.App.Backend.DbModel.Entities.Projects;
+using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Enums;
+using Sig.App.Backend.Extensions;
+using Sig.App.Backend.Requests.Commands.Mutations.Subscriptions;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
+{
+    public class ChangeBeneficiarySubscriptionMaxNumberOfPaymentsTest : TestBase
+    {
+        private readonly ChangeBeneficiarySubscriptionMaxNumberOfPayments handler;
+
+        private readonly Subscription subscription;
+        private readonly Beneficiary beneficiary;
+        private readonly BudgetAllowance budgetAllowance;
+        private readonly SubscriptionBeneficiary subscriptionBeneficiary;
+
+        public ChangeBeneficiarySubscriptionMaxNumberOfPaymentsTest()
+        {
+            var project = new Project()
+            {
+                Name = "Project 1"
+            };
+            DbContext.Projects.Add(project);
+
+            var organization = new Organization()
+            {
+                Name = "Organization 1",
+                Project = project
+            };
+            DbContext.Organizations.Add(organization);
+
+            var beneficiaryType = new BeneficiaryType()
+            {
+                Project = project,
+                Keys = "Beneficiary type 1",
+                Name = "Beneficiary type 1"
+            };
+            DbContext.BeneficiaryTypes.Add(beneficiaryType);
+
+            beneficiary = new Beneficiary()
+            {
+                Firstname = "John",
+                Lastname = "Doe",
+                Address = "123, example street",
+                Email = "john.doe@example.com",
+                Phone = "555-555-1234",
+                BeneficiaryType = beneficiaryType,
+                Organization = organization
+            };
+            DbContext.Beneficiaries.Add(beneficiary);
+
+            var productGroup = new ProductGroup()
+            {
+                Project = project,
+                Color = ProductGroupColor.Color_1,
+                Name = "Product group 1",
+                OrderOfAppearance = 1
+            };
+            DbContext.ProductGroups.Add(productGroup);
+
+            var today = Clock.GetCurrentInstant().ToDateTimeUtc();
+            subscription = new Subscription()
+            {
+                Name = "Subscription 1",
+                StartDate = new DateTime(today.Year, today.Month, 1),
+                EndDate = new DateTime(today.Year, today.Month, 1).AddMonths(6),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
+                IsSubscriptionPaymentBasedCardUsage = true,
+                MaxNumberOfPayments = 3,
+                Types = new List<SubscriptionType>()
+                {
+                    new SubscriptionType()
+                    {
+                        Amount = 50,
+                        BeneficiaryType = beneficiaryType,
+                        ProductGroup = productGroup
+                    }
+                },
+                Project = project
+            };
+            DbContext.Subscriptions.Add(subscription);
+
+            budgetAllowance = new BudgetAllowance()
+            {
+                AvailableFund = 500,
+                Organization = organization,
+                Subscription = subscription,
+                OriginalFund = 500
+            };
+            DbContext.BudgetAllowances.Add(budgetAllowance);
+
+            subscriptionBeneficiary = new SubscriptionBeneficiary()
+            {
+                Beneficiary = beneficiary,
+                Subscription = subscription,
+                BeneficiaryType = beneficiaryType,
+                BudgetAllowance = budgetAllowance
+            };
+            subscription.Beneficiaries = new List<SubscriptionBeneficiary>() { subscriptionBeneficiary };
+
+            DbContext.SaveChanges();
+
+            handler = new ChangeBeneficiarySubscriptionMaxNumberOfPayments(
+                NullLogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments>.Instance,
+                DbContext);
+        }
+
+        [Fact]
+        public async Task IncreaseMaxNumberOfPaymentsDeductsBudgetAllowance()
+        {
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 5
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var localSubscriptionBeneficiary = await DbContext.SubscriptionBeneficiaries
+                .Include(x => x.BudgetAllowance)
+                .FirstAsync(x => x.BeneficiaryId == beneficiary.Id && x.SubscriptionId == subscription.Id);
+
+            // 5 - 3 = 2 additional payments * 50 = 100 deducted
+            localSubscriptionBeneficiary.MaxNumberOfPaymentsOverride.Should().Be(5);
+            localSubscriptionBeneficiary.BudgetAllowance.AvailableFund.Should().Be(400);
+        }
+
+        [Fact]
+        public async Task IncreaseFromExistingOverrideDeductsOnlyDifference()
+        {
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 5;
+            DbContext.SaveChanges();
+
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 7
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var localSubscriptionBeneficiary = await DbContext.SubscriptionBeneficiaries
+                .Include(x => x.BudgetAllowance)
+                .FirstAsync(x => x.BeneficiaryId == beneficiary.Id && x.SubscriptionId == subscription.Id);
+
+            // 7 - 5 = 2 additional payments * 50 = 100 deducted
+            localSubscriptionBeneficiary.MaxNumberOfPaymentsOverride.Should().Be(7);
+            localSubscriptionBeneficiary.BudgetAllowance.AvailableFund.Should().Be(400);
+        }
+
+        [Fact]
+        public async Task ThrowsIfBeneficiaryNotInSubscription()
+        {
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = Id.New<Subscription>(123456),
+                MaxNumberOfPayments = 5
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.BeneficiaryNotInSubscriptionException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfMaxNumberOfPaymentsIsEqualToCurrentMax()
+        {
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 3
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.MaxNumberOfPaymentsMustBeGreaterThanCurrentException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfMaxNumberOfPaymentsIsLessThanCurrentMax()
+        {
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 1
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.MaxNumberOfPaymentsMustBeGreaterThanCurrentException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfMaxNumberOfPaymentsIsLessThanCurrentOverride()
+        {
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 5;
+            DbContext.SaveChanges();
+
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 4
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.MaxNumberOfPaymentsMustBeGreaterThanCurrentException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfNotEnoughBudgetAllowance()
+        {
+            budgetAllowance.AvailableFund = 0;
+            DbContext.SaveChanges();
+
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 5
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.NotEnoughBudgetAllowanceException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfBudgetAllowanceCoversOnlyPartOfAdditionalPayments()
+        {
+            budgetAllowance.AvailableFund = 50; // enough for 1 payment but not 2
+            DbContext.SaveChanges();
+
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 5 // requires 2 additional payments = 100
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.NotEnoughBudgetAllowanceException>();
+        }
+    }
+}

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscriptionTest.cs
@@ -244,6 +244,54 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         }
 
         [Fact]
+        public async Task RemoveBeneficiaryFromSubscriptionWithMaxNumberOfPaymentsOverride()
+        {
+            var today = Clock.GetCurrentInstant().ToDateTimeUtc();
+
+            subscription.IsSubscriptionPaymentBasedCardUsage = true;
+            subscription.MaxNumberOfPayments = 1;
+            subscription.EndDate = new DateTime(today.Year, today.Month, 2).AddMonths(4);
+            var subscriptionBeneficiary = subscription.Beneficiaries.First();
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 3;
+
+            beneficiary.Card = new Card()
+            {
+                Transactions = new List<Transaction>() {
+                    new SubscriptionAddingFundTransaction()
+                    {
+                        Amount = 25,
+                        SubscriptionType = new SubscriptionType()
+                        {
+                            Subscription = subscription,
+                            ProductGroup = subscription.Types.First(x => x.BeneficiaryType == beneficiary.BeneficiaryType).ProductGroup,
+                            BeneficiaryType = beneficiary.BeneficiaryType
+                        },
+                        Beneficiary = beneficiary
+                    }
+                }
+            };
+
+            DbContext.SaveChanges();
+
+            var input = new RemoveBeneficiaryFromSubscription.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier()
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var localBudgetAllowance = await DbContext.BudgetAllowances.FirstAsync();
+            var transactionLogCreated = await DbContext.TransactionLogs.AnyAsync(x => x.Discriminator == TransactionLogDiscriminator.RefundBudgetAllowanceFromRemovedBeneficiaryFromSubscriptionTransactionLog);
+
+            // maxNumberOfPayments = override=3, transactionCount=1
+            // paymentsRemaining = max(0, min(calendarRemaining>=3, 3-1)) = 2
+            // totalRefund = 2 * 25 = 50
+            localBudgetAllowance.AvailableFund.Should().Be(75);
+            transactionLogCreated.Should().Be(true);
+        }
+
+        [Fact]
         public async Task ThrowsIfSubsriptionNotFound()
         {
             var input = new RemoveBeneficiaryFromSubscription.Input()

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddMissingPaymentTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddMissingPaymentTest.cs
@@ -404,6 +404,81 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
         }
 
         [Fact]
+        public async Task ThrowsIfMaxNumberOfPaymentsOverrideIsReached()
+        {
+            subscription.StartDate = Clock.GetCurrentInstant().ToDateTimeUtc().AddMonths(-4);
+            var subscriptionBeneficiary = beneficiary.Subscriptions.First();
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 1;
+
+            card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                Amount = 25,
+                AvailableFund = 25,
+                Beneficiary = beneficiary,
+                Card = card,
+                CreatedAtUtc = Clock.GetCurrentInstant().ToDateTimeUtc(),
+                ExpirationDate = subscription.GetExpirationDate(Clock),
+                Organization = organization,
+                ProductGroup = productGroup,
+                Status = FundTransactionStatus.Actived,
+                SubscriptionType = subscription.Types.First(),
+            });
+
+            DbContext.SaveChanges();
+
+            var input = new AddMissingPayment.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier()
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<AddMissingPayment.SubscriptionDontHaveMissedPaymentException>();
+        }
+
+        [Fact]
+        public async Task AllowsPaymentWhenOverrideIsHigherThanSubscriptionMax()
+        {
+            var today = Clock.GetCurrentInstant().ToDateTimeUtc();
+
+            subscription.MaxNumberOfPayments = 1;
+            subscription.StartDate = new DateTime(today.Year, today.Month, 1).AddMonths(-4);
+            subscription.EndDate = new DateTime(today.Year, today.Month, 1).AddMonths(6);
+            subscription.FundsExpirationDate = new DateTime(today.Year, today.Month, 1).AddMonths(7);
+
+            var subscriptionBeneficiary = beneficiary.Subscriptions.First();
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 2;
+
+            card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                Amount = 25,
+                AvailableFund = 25,
+                Beneficiary = beneficiary,
+                Card = card,
+                CreatedAtUtc = Clock.GetCurrentInstant().ToDateTimeUtc(),
+                ExpirationDate = subscription.GetExpirationDate(Clock),
+                Organization = organization,
+                ProductGroup = productGroup,
+                Status = FundTransactionStatus.Actived,
+                SubscriptionType = subscription.Types.First(),
+            });
+
+            DbContext.SaveChanges();
+
+            var input = new AddMissingPayment.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier()
+            };
+
+            // override=2 > transactionCount=1, so no exception; budget already allocated
+            await handler.Handle(input, CancellationToken.None);
+
+            var localBudgetAllowance = DbContext.BudgetAllowances.First();
+            localBudgetAllowance.AvailableFund.Should().Be(100);
+        }
+
+        [Fact]
         public async Task SubscriptionDontHaveEnoughtAvailableAmount()
         {
             budgetAllowance.AvailableFund = 0;

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddMissingPaymentsTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddMissingPaymentsTest.cs
@@ -352,6 +352,81 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
         }
 
         [Fact]
+        public async Task ThrowsIfMaxNumberOfPaymentsOverrideIsReached()
+        {
+            subscription.StartDate = Clock.GetCurrentInstant().ToDateTimeUtc().AddMonths(-4);
+            var subscriptionBeneficiary = beneficiary.Subscriptions.First();
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 1;
+
+            card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                Amount = 25,
+                AvailableFund = 25,
+                Beneficiary = beneficiary,
+                Card = card,
+                CreatedAtUtc = Clock.GetCurrentInstant().ToDateTimeUtc(),
+                ExpirationDate = subscription.GetExpirationDate(Clock),
+                Organization = organization,
+                ProductGroup = productGroup,
+                Status = FundTransactionStatus.Actived,
+                SubscriptionType = subscription.Types.First(),
+            });
+
+            DbContext.SaveChanges();
+
+            var input = new AddMissingPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                Subscriptions = new List<Id>() { subscription.GetIdentifier() }
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<AddMissingPayments.SubscriptionDontHaveMissedPaymentException>();
+        }
+
+        [Fact]
+        public async Task AllowsPaymentWhenOverrideIsHigherThanSubscriptionMax()
+        {
+            var today = Clock.GetCurrentInstant().ToDateTimeUtc();
+
+            subscription.MaxNumberOfPayments = 1;
+            subscription.StartDate = new DateTime(today.Year, today.Month, 1).AddMonths(-4);
+            subscription.EndDate = new DateTime(today.Year, today.Month, 1).AddMonths(6);
+            subscription.FundsExpirationDate = new DateTime(today.Year, today.Month, 1).AddMonths(7);
+
+            var subscriptionBeneficiary = beneficiary.Subscriptions.First();
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 2;
+
+            card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                Amount = 25,
+                AvailableFund = 25,
+                Beneficiary = beneficiary,
+                Card = card,
+                CreatedAtUtc = Clock.GetCurrentInstant().ToDateTimeUtc(),
+                ExpirationDate = subscription.GetExpirationDate(Clock),
+                Organization = organization,
+                ProductGroup = productGroup,
+                Status = FundTransactionStatus.Actived,
+                SubscriptionType = subscription.Types.First(),
+            });
+
+            DbContext.SaveChanges();
+
+            var input = new AddMissingPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                Subscriptions = new List<Id>() { subscription.GetIdentifier() }
+            };
+
+            // override=2 > transactionCount=1, so no exception; AddMissingPayments always deducts budget
+            await handler.Handle(input, CancellationToken.None);
+
+            var localBudgetAllowance = DbContext.BudgetAllowances.First();
+            localBudgetAllowance.AvailableFund.Should().Be(75);
+        }
+
+        [Fact]
         public async Task SubscriptionDontHaveEnoughtAvailableAmount()
         {
             budgetAllowance.AvailableFund = 0;

--- a/Sig.App.Frontend/src/components/beneficiaries/beneficiary-actions.vue
+++ b/Sig.App.Frontend/src/components/beneficiaries/beneficiary-actions.vue
@@ -29,7 +29,9 @@
       "transfer-funds": "Transfer funds",
       "beneficiary-transfer-funds-disabled-no-card": "You can't transfer funds if the beneficiary doesn't have a card",
       "beneficiary-transfer-funds-disabled-no-subscription": "You can't transfer funds if the beneficiary doesn't have a subscription",
-      "beneficiary-transfer-funds-disabled-all-group": "You can't transfer funds if all groups are selected"
+      "beneficiary-transfer-funds-disabled-all-group": "You can't transfer funds if all groups are selected",
+      "change-max-number-of-payments": "Change maximum number of payments",
+      "change-max-number-of-payments-disabled": "You can't change the maximum number of payments if the participant has no eligible subscriptions"
     },
     "fr": {
       "beneficiary-edit": "Modifier les détails",
@@ -60,7 +62,9 @@
       "transfer-funds": "Transférer des fonds",
       "beneficiary-transfer-funds-disabled-no-card": "Vous ne pouvez pas transférer des fonds si le-a participant-e n'a pas de carte",
       "beneficiary-transfer-funds-disabled-no-subscription": "Vous ne pouvez pas transférer des fonds si le-a participant-e n'a pas d'abonnement",
-      "beneficiary-transfer-funds-disabled-all-group": "Vous ne pouvez pas transférer des fonds si tous les groupes sont sélectionnés"
+      "beneficiary-transfer-funds-disabled-all-group": "Vous ne pouvez pas transférer des fonds si tous les groupes sont sélectionnés",
+      "change-max-number-of-payments": "Modifier le nombre maximum de paiements",
+      "change-max-number-of-payments-disabled": "Vous ne pouvez pas modifier le nombre maximum de paiements si le-a participant-e n'a pas d'abonnement admissible"
     }
   }
 </i18n>
@@ -89,6 +93,7 @@ import ICON_CLOSE from "@/lib/icons/close.json";
 import ICON_CONFLICT from "@/lib/icons/exclamation-circle.json";
 import ICON_IDENTIFICATION from "@/lib/icons/identification.json";
 import ICON_TRANSACTION from "@/lib/icons/add-square.json";
+import ICON_RECEIPT_TAX from "@/lib/icons/receipt-tax.json";
 
 import {
   URL_BENEFICIARY_EDIT,
@@ -103,7 +108,8 @@ import {
   URL_BENEFICIARY_MANAGE_CONFLICT,
   URL_BENEFICIARY_ASSIGN_SUBSCRIPTIONS,
   URL_BENEFICIARY_TRANSACTION_ADD,
-  URL_BENEFICIARY_TRANSFER_FUNDS
+  URL_BENEFICIARY_TRANSFER_FUNDS,
+  URL_BENEFICIARY_CHANGE_MAX_NUMBER_OF_PAYMENTS
 } from "@/lib/consts/urls";
 
 import { GLOBAL_MANAGE_CARDS } from "@/lib/consts/permissions";
@@ -174,6 +180,14 @@ function updateItems() {
           : !haveSubscriptions()
             ? t("beneficiary-transfer-funds-disabled-no-subscription")
             : t("beneficiary-transfer-funds-disabled-all-group")
+      },
+      {
+        isExtra: true,
+        icon: ICON_RECEIPT_TAX,
+        label: t("change-max-number-of-payments"),
+        route: { name: URL_BENEFICIARY_CHANGE_MAX_NUMBER_OF_PAYMENTS, params: { beneficiaryId: props.beneficiary.id } },
+        disabled: !havePaymentBasedSubscriptions(),
+        reason: t("change-max-number-of-payments-disabled")
       },
       {
         isExtra: true,
@@ -321,6 +335,10 @@ function isCardDisabled() {
 
 function haveSubscriptions() {
   return props.beneficiary.beneficiarySubscriptions.length > 0;
+}
+
+function havePaymentBasedSubscriptions() {
+  return props.beneficiary.beneficiarySubscriptions.some((x) => x.subscription.isSubscriptionPaymentBasedCardUsage);
 }
 
 function haveMarketsInOrganization() {

--- a/Sig.App.Frontend/src/lib/consts/urls.js
+++ b/Sig.App.Frontend/src/lib/consts/urls.js
@@ -115,6 +115,7 @@ export const URL_BENEFICIARY_TRANSACTION_ADD = "beneficiary-transaction-add-url"
 export const URL_BENEFICIARY_ADMIN_AVAILABLE_AMOUNT_FOR_ALLOCATION = "beneficiary-admin-available-amount-for-allocation-url";
 export const URL_BENEFICIARY_TRANSFER_FUNDS = "beneficiary-transfer-funds-url";
 export const URL_BENEFICIARY_EDIT_GIFT_CARD = "beneficiary-edit-gift-card-url";
+export const URL_BENEFICIARY_CHANGE_MAX_NUMBER_OF_PAYMENTS = "beneficiary-change-max-number-of-payments-url";
 
 export const URL_PROJECT_MANAGER_ADMIN = "project-manager-list-url";
 export const URL_PROJECT_MANAGER_ADD = "project-manager-add-url";

--- a/Sig.App.Frontend/src/lib/router/routes.js
+++ b/Sig.App.Frontend/src/lib/router/routes.js
@@ -908,6 +908,14 @@ export default [
             }
           },
           {
+            name: urls.URL_BENEFICIARY_CHANGE_MAX_NUMBER_OF_PAYMENTS,
+            path: ":beneficiaryId/change-max-payments",
+            component: () => import("@/views/beneficiary/ChangeMaxNumberOfPayments.vue"),
+            meta: {
+              claim: GLOBAL_MANAGE_BENEFICIARIES
+            }
+          },
+          {
             name: urls.URL_BENEFICIARY_IMPORT_LIST,
             path: "import",
             component: () => import("@/views/beneficiary/ImportList.vue"),

--- a/Sig.App.Frontend/src/views/beneficiary/ChangeMaxNumberOfPayments.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ChangeMaxNumberOfPayments.vue
@@ -1,0 +1,221 @@
+<i18n>
+{
+  "en": {
+    "title": "Change maximum number of payments",
+    "select-subscription-label": "Subscription",
+    "max-number-of-payments-label": "New maximum number of payments",
+    "cancel": "Cancel",
+    "submit": "Save changes",
+    "additional-cost": "{amount} will be deducted from the budget allowance",
+    "budget-allowance-available": "Remaining budget allowance after change: {amount}",
+    "success-notification": "The maximum number of payments has been updated successfully.",
+    "must-be-greater-than-current": "Must be greater than the current maximum ({current})",
+    "must-be-a-number": "Must be a valid number"
+  },
+  "fr": {
+    "title": "Modifier le nombre maximum de paiements",
+    "select-subscription-label": "Abonnement",
+    "max-number-of-payments-label": "Nouveau nombre maximum de paiements",
+    "cancel": "Annuler",
+    "submit": "Enregistrer les modifications",
+    "additional-cost": "{amount} seront déduits de l'enveloppe",
+    "budget-allowance-available": "Enveloppe restante après modification : {amount}",
+    "success-notification": "Le nombre maximum de paiements a été mis à jour avec succès.",
+    "must-be-greater-than-current": "Doit être supérieur au maximum actuel ({current})",
+    "must-be-a-number": "Doit être un nombre valide"
+  }
+}
+</i18n>
+
+<template>
+  <UiDialogModal v-if="!loading" v-slot="{ closeModal }" :title="t('title')" :has-footer="false"
+    :return-route="{ name: URL_BENEFICIARY_ADMIN }">
+    <Form v-slot="{ isSubmitting, errors: formErrors, setFieldValue }" :validation-schema="validationSchema"
+      @submit="onSubmit">
+      <PfForm has-footer can-cancel
+        :disable-submit="Object.keys(formErrors).length > 0 || budgetAllowanceAvailableAfterChange < 0"
+        :submit-label="t('submit')" :cancel-label="t('cancel')" :processing="isSubmitting" @cancel="closeModal">
+        <PfFormSection>
+          <Field v-slot="{ field, errors: fieldErrors }" name="subscription">
+            <PfFormInputSelect id="subscription" v-bind="field" :label="t('select-subscription-label')"
+              :options="subscriptionOptions" :errors="fieldErrors"
+              @input="(e) => onSubscriptionSelected(e, setFieldValue)" />
+          </Field>
+          <Field v-slot="{ field, errors: fieldErrors }" name="maxNumberOfPayments">
+            <PfFormInputText id="maxNumberOfPayments" v-bind="field" input-type="number"
+              :label="t('max-number-of-payments-label')" :disabled="selectedSubscription === ''" :errors="fieldErrors"
+              @input="onMaxPaymentsInput" />
+          </Field>
+          <div v-if="selectedSubscription !== ''" class="flex flex-col">
+            <h2 class="my-2">{{ t("additional-cost", { amount: additionalCostMoneyFormat }) }}</h2>
+            <p class="my-0" :class="{ 'text-red-500 font-bold': budgetAllowanceAvailableAfterChange < 0 }">
+              {{ t("budget-allowance-available", { amount: budgetAllowanceAvailableAfterChangeMoneyFormat }) }}
+            </p>
+          </div>
+        </PfFormSection>
+      </PfForm>
+    </Form>
+  </UiDialogModal>
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+import { useI18n } from "vue-i18n";
+import gql from "graphql-tag";
+import { useQuery, useResult, useMutation } from "@vue/apollo-composable";
+import { useRoute, useRouter } from "vue-router";
+import { object, string, number } from "yup";
+import { Form, Field } from "vee-validate";
+
+import { getMoneyFormat } from "@/lib/helpers/money";
+import { subscriptionName } from "@/lib/helpers/subscription";
+import { useNotificationsStore } from "@/lib/store/notifications";
+import { URL_BENEFICIARY_ADMIN } from "@/lib/consts/urls";
+
+const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
+const { addSuccess } = useNotificationsStore();
+
+const selectedSubscription = ref("");
+const newMaxNumberOfPayments = ref(0);
+
+const validationSchema = computed(() => {
+  const currentMax = selectedSubscriptionData.value?.currentMax ?? 0;
+  return object({
+    subscription: string().label(t("select-subscription-label")).required(),
+    maxNumberOfPayments: number()
+      .typeError(t("must-be-a-number"))
+      .label(t("max-number-of-payments-label"))
+      .required()
+      .integer()
+      .min(currentMax + 1, t("must-be-greater-than-current", { current: currentMax }))
+  });
+});
+
+const { result: resultBeneficiary, loading } = useQuery(
+  gql`
+    query BeneficiaryForChangeMaxPayments($id: ID!) {
+      beneficiary(id: $id) {
+        id
+        ... on BeneficiaryGraphType {
+          beneficiaryType {
+            id
+          }
+          organization {
+            id
+          }
+          beneficiarySubscriptions {
+            maxNumberOfPayments
+            subscription {
+              id
+              name
+              isArchived
+              isSubscriptionPaymentBasedCardUsage
+              types {
+                id
+                amount
+                beneficiaryType {
+                  id
+                }
+              }
+              budgetAllowances {
+                id
+                availableFund
+                organization {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  {
+    id: route.params.beneficiaryId
+  }
+);
+
+const beneficiary = useResult(resultBeneficiary, null, (data) => data.beneficiary);
+
+const subscriptionOptions = useResult(resultBeneficiary, [], (data) => {
+  return data.beneficiary.beneficiarySubscriptions
+    .filter((x) => x.subscription.isSubscriptionPaymentBasedCardUsage && !x.subscription.isArchived)
+    .map((x) => ({
+      label: subscriptionName(x.subscription),
+      value: x.subscription.id,
+      currentMax: x.maxNumberOfPayments,
+      types: x.subscription.types,
+      budgetAllowance:
+        x.subscription.budgetAllowances.find((b) => b.organization.id === data.beneficiary.organization.id)?.availableFund ?? 0
+    }));
+});
+
+const selectedSubscriptionData = computed(() => {
+  if (!selectedSubscription.value || !subscriptionOptions.value) return null;
+  return subscriptionOptions.value.find((x) => x.value === selectedSubscription.value);
+});
+
+const { mutate: changeBeneficiarySubscriptionMaxNumberOfPaymentsMutation } = useMutation(
+  gql`
+    mutation ChangeBeneficiarySubscriptionMaxNumberOfPayments($input: ChangeBeneficiarySubscriptionMaxNumberOfPaymentsInput!) {
+      changeBeneficiarySubscriptionMaxNumberOfPayments(input: $input) {
+        beneficiary {
+          id
+        }
+      }
+    }
+  `
+);
+
+async function onSubmit({ subscription, maxNumberOfPayments }) {
+  await changeBeneficiarySubscriptionMaxNumberOfPaymentsMutation({
+    input: {
+      beneficiaryId: route.params.beneficiaryId,
+      subscriptionId: subscription,
+      maxNumberOfPayments: parseInt(maxNumberOfPayments, 10)
+    }
+  });
+  addSuccess(t("success-notification"));
+  router.push({ name: URL_BENEFICIARY_ADMIN });
+}
+
+function onSubscriptionSelected(value, setFieldValue) {
+  selectedSubscription.value = value;
+  const data = subscriptionOptions.value?.find((x) => x.value === value);
+  if (data) {
+    newMaxNumberOfPayments.value = data.currentMax;
+    setFieldValue("maxNumberOfPayments", data.currentMax);
+  }
+}
+
+function onMaxPaymentsInput(e) {
+  const raw = e && e.target ? e.target.value : e;
+  const parsed = parseInt(raw, 10);
+  newMaxNumberOfPayments.value = isNaN(parsed) ? 0 : parsed;
+}
+
+const additionalCost = computed(() => {
+  if (!selectedSubscriptionData.value || !beneficiary.value) return 0;
+  const currentMax = selectedSubscriptionData.value.currentMax;
+  const additional = Math.max(0, newMaxNumberOfPayments.value - currentMax);
+  const amountPerPayment = selectedSubscriptionData.value.types
+    .filter((type) => type.beneficiaryType.id === beneficiary.value.beneficiaryType.id)
+    .reduce((sum, type) => sum + type.amount, 0);
+  return additional * amountPerPayment;
+});
+
+const additionalCostMoneyFormat = computed(() => {
+  return additionalCost.value > 0 ? getMoneyFormat(additionalCost.value) : "-";
+});
+
+const budgetAllowanceAvailableAfterChange = computed(() => {
+  if (!selectedSubscriptionData.value) return 0;
+  return selectedSubscriptionData.value.budgetAllowance - additionalCost.value;
+});
+
+const budgetAllowanceAvailableAfterChangeMoneyFormat = computed(() => {
+  return getMoneyFormat(budgetAllowanceAvailableAfterChange.value);
+});
+</script>

--- a/Sig.App.Frontend/src/views/beneficiary/ChangeMaxNumberOfPayments.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ChangeMaxNumberOfPayments.vue
@@ -46,7 +46,7 @@
               :label="t('max-number-of-payments-label')" :disabled="selectedSubscription === ''" :errors="fieldErrors"
               @input="onMaxPaymentsInput" />
           </Field>
-          <div v-if="selectedSubscription !== ''" class="flex flex-col">
+          <div v-if="selectedSubscription !== ''">
             <h2 class="my-2">{{ t("additional-cost", { amount: additionalCostMoneyFormat }) }}</h2>
             <p class="my-0" :class="{ 'text-red-500 font-bold': budgetAllowanceAvailableAfterChange < 0 }">
               {{ t("budget-allowance-available", { amount: budgetAllowanceAvailableAfterChangeMoneyFormat }) }}

--- a/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
@@ -617,6 +617,7 @@ const {
                   isArchived
                   name
                   endDate
+                  isSubscriptionPaymentBasedCardUsage
                   types {
                     id
                     beneficiaryType {
@@ -758,6 +759,7 @@ const {
                   isArchived
                   name
                   endDate
+                  isSubscriptionPaymentBasedCardUsage
                   types {
                     id
                     beneficiaryType {

--- a/Sig.App.Frontend/src/views/beneficiary/ManageConflict.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ManageConflict.vue
@@ -123,6 +123,7 @@ const { result: resultBeneficiary } = useQuery(
               name
             }
             paymentReceived
+            maxNumberOfPayments
             subscription {
               id
               isArchived
@@ -202,7 +203,7 @@ const beneficiarySubscriptionsWithConflict = computed(() => {
 
       const numberOfPaymentToReceive = Math.min(
         beneficiarySubscription.subscription.maxNumberOfPayments !== null
-          ? beneficiarySubscription.subscription.maxNumberOfPayments - beneficiarySubscription.paymentReceived
+          ? beneficiarySubscription.maxNumberOfPayments - beneficiarySubscription.paymentReceived
           : paymentRemaining,
         paymentRemaining
       );


### PR DESCRIPTION
[JIRA - Permettre à un participant de recommencer un abonnement avec des versements limités](https://sigmund-ca.atlassian.net/browse/CRCL-2209)

- Option « Ajuster le nombre de versements » (“Modifier the number of payments”) dans le menu pop-out d’un-e participant-e
- Ça ouvre une modal comme tu l’as décrit, avec un champs select qui inclut uniquement les abonnements attribués à cette carte et ayant un nombre maximum de versements
- Champ de type number avec la valeur par défaut correspondant au nombre de versements maximum de l’abonnement s’il n’a pas été modifié.
- Limiter à l’augmentation du nombre et non la diminution