### PR TITLE
Add MarketGroup in Transactions report / Add couple of test to validate TransactionLog

### DIFF
--- a/Sig.App.Backend/DataSeeders/DevDataSeeder.cs
+++ b/Sig.App.Backend/DataSeeders/DevDataSeeder.cs
@@ -519,7 +519,7 @@ public class DevDataSeeder : IDataSeeder
         var project = db.Projects.FirstOrDefault(x => x.Name == "SeedDev - Programme 1");
         var market = db.Markets.FirstOrDefault(x => x.Name == "SeedDev - Commerce 1");
         var productGroup = db.ProductGroups.FirstOrDefault(x => x.Name == "SeedDev - Groupe1");
-        var cashRegister = db.CashRegisters.FirstOrDefault(x => x.Name == "SeedDev - Caisse 1");
+        var cashRegister = db.CashRegisters.Include(x => x.MarketGroups).ThenInclude(x => x.MarketGroup).FirstOrDefault(x => x.Name == "SeedDev - Caisse 1");
 
         if (beneficiary == null || project == null || market == null)
         {
@@ -593,7 +593,9 @@ public class DevDataSeeder : IDataSeeder
             MarketName = market.Name,
             TransactionLogProductGroups = transactionLogProductGroups,
             CashRegisterId = cashRegister.Id,
-            CashRegisterName = cashRegister.Name
+            CashRegisterName = cashRegister.Name,
+            MarketGroupId = cashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroupId,
+            MarketGroupName = cashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroup?.Name
         });
         
         var transaction2 = new PaymentTransaction() { TransactionUniqueId = TransactionHelper.CreateTransactionUniqueId(), Amount = 32.33m, CreatedAtUtc = DateTime.UtcNow.AddMonths(-1), Card = card, Beneficiary = beneficiary, Organization = beneficiary.Organization, Market = market, Transactions = new List<AddingFundTransaction>(), PaymentTransactionAddingFundTransactions = new List<PaymentTransactionAddingFundTransaction>(), CashRegister = cashRegister };
@@ -649,7 +651,9 @@ public class DevDataSeeder : IDataSeeder
             MarketName = market.Name,
             TransactionLogProductGroups = transactionLogProductGroups,
             CashRegisterId = cashRegister.Id,
-            CashRegisterName = cashRegister.Name
+            CashRegisterName = cashRegister.Name,
+            MarketGroupId = cashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroupId,
+            MarketGroupName = cashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroup?.Name
         });
 
         await db.SaveChangesAsync();

--- a/Sig.App.Backend/DbModel/Entities/TransactionLogs/TransactionLog.cs
+++ b/Sig.App.Backend/DbModel/Entities/TransactionLogs/TransactionLog.cs
@@ -46,6 +46,8 @@ public class TransactionLog : IHaveLongIdentifier
 
     public long? CashRegisterId { get; set; }
     public string CashRegisterName { get; set; }
+    public long? MarketGroupId { get; set; }
+    public string MarketGroupName { get; set; }
 
     public List<TransactionLogProductGroup> TransactionLogProductGroups { get; set; }
 }

--- a/Sig.App.Backend/Migrations/20260408021028_AddMarketGroupToTransactionLog.Designer.cs
+++ b/Sig.App.Backend/Migrations/20260408021028_AddMarketGroupToTransactionLog.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sig.App.Backend.DbModel;
 
@@ -11,9 +12,11 @@ using Sig.App.Backend.DbModel;
 namespace Sig.App.Backend.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408021028_AddMarketGroupToTransactionLog")]
+    partial class AddMarketGroupToTransactionLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sig.App.Backend/Migrations/20260408021028_AddMarketGroupToTransactionLog.cs
+++ b/Sig.App.Backend/Migrations/20260408021028_AddMarketGroupToTransactionLog.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sig.App.Backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMarketGroupToTransactionLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "MarketGroupId",
+                table: "TransactionLogs",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MarketGroupName",
+                table: "TransactionLogs",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MarketGroupId",
+                table: "TransactionLogs");
+
+            migrationBuilder.DropColumn(
+                name: "MarketGroupName",
+                table: "TransactionLogs");
+        }
+    }
+}

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/CreateTransaction.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/CreateTransaction.cs
@@ -404,7 +404,9 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                     InitiatedByProject = currentUser?.Type == UserType.ProjectManager,
                     InitiatedByOrganization = currentUser?.Type == UserType.OrganizationManager,
                     CashRegisterId = paymentTransaction.CashRegister != null ? paymentTransaction.CashRegister.Id : null,
-                    CashRegisterName = paymentTransaction.CashRegister != null ? paymentTransaction.CashRegister.Name : ""
+                    CashRegisterName = paymentTransaction.CashRegister != null ? paymentTransaction.CashRegister.Name : "",
+                    MarketGroupId = paymentTransaction.CashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroupId,
+                    MarketGroupName = paymentTransaction.CashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroup?.Name
                 };
                 transactionLogs.Add(transactionLog);
             }

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/RefundTransaction.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/RefundTransaction.cs
@@ -72,7 +72,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                 .Include(x => x.Organization)
                 .Include(x => x.Transactions)
                 .Include(x => x.PaymentTransactionAddingFundTransactions).ThenInclude(x => x.AddingFundTransaction)
-                .Include(x => x.CashRegister)
+                .Include(x => x.CashRegister).ThenInclude(x => x.MarketGroups).ThenInclude(x => x.MarketGroup)
                 .FirstOrDefaultAsync(x => x.Id == initialTransactionId, cancellationToken);
 
             if (initialTransaction == null)
@@ -145,7 +145,9 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                 InitiatedByProject = currentUser?.Type == UserType.ProjectManager,
                 InitiatedByOrganization = currentUser?.Type == UserType.OrganizationManager,
                 CashRegisterId = initialTransaction.CashRegisterId,
-                CashRegisterName = initialTransaction.CashRegister?.Name
+                CashRegisterName = initialTransaction.CashRegister?.Name,
+                MarketGroupId = initialTransaction.CashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroupId,
+                MarketGroupName = initialTransaction.CashRegister?.MarketGroups?.FirstOrDefault(x => x.MarketGroup.ProjectId == card.ProjectId)?.MarketGroup?.Name
             };
             transactionLogs.Add(baseTransactionLog);
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/RefundTransaction.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/RefundTransaction.cs
@@ -65,6 +65,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
             var initialTransaction = await db.Transactions.OfType<PaymentTransaction>()
                 .Include(x => x.Card).ThenInclude(x => x.Funds).ThenInclude(x => x.ProductGroup)
                 .Include(x => x.Card).ThenInclude(x => x.Project)
+                .AsSplitQuery()
                 .Include(x => x.Beneficiary)
                 .Include(x => x.Market)
                 .Include(x => x.TransactionByProductGroups)

--- a/Sig.App.Backend/Services/Reports/ReportService.cs
+++ b/Sig.App.Backend/Services/Reports/ReportService.cs
@@ -78,6 +78,8 @@ namespace Sig.App.Backend.Services.Reports
             dataWorksheet.Column("Id de la carte/Card id", x => x.CardProgramCardId);
             dataWorksheet.Column("Numéro de la carte/Card number", x => x.CardNumber != null ? x.CardNumber.Replace("-", " ") : "");
             dataWorksheet.Column("Caisse/Cash register", x => x.CashRegisterName);
+            dataWorksheet.Column("ID Groupe de commerces/ID Market group", x => x.MarketGroupId);
+            dataWorksheet.Column("Groupe de commerces/Market group", x => x.MarketGroupName);
 
             return generator.Render();
         }
@@ -239,6 +241,8 @@ namespace Sig.App.Backend.Services.Reports
             dataWorksheet.Column("Initiateur transaction/Transaction initiator", GetTransactionInitiatorName);
             dataWorksheet.Column("Courriel initiateur transaction/Transaction initiator email", x => x.TransactionInitiatorEmail);
             dataWorksheet.Column("Caisse/Cash register", x => x.CashRegisterName);
+            dataWorksheet.Column("ID Groupe de commerces/ID Market group", x => x.MarketGroupId);
+            dataWorksheet.Column("Groupe de commerces/Market group", x => x.MarketGroupName);
 
             return generator.Render();
         }

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Cards/TransfertCardTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Cards/TransfertCardTest.cs
@@ -26,10 +26,11 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Cards
         private readonly Card originalCard;
         private readonly Card newCard;
         private readonly ProductGroup productGroup;
+        private readonly Project project;
 
         public TransfertCardTest()
         {
-            var project = new Project()
+            project = new Project()
             {
                 Name = "Project 1"
             };
@@ -155,6 +156,25 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Cards
             var transactionLogCreated = await DbContext.TransactionLogs
                 .Where(x => x.Discriminator == TransactionLogDiscriminator.TransferFundTransactionLog).ToListAsync();
             transactionLogCreated.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task TransfertCardCreatesTransactionLogWithCorrectFields()
+        {
+            var input = new TransfertCard.Input()
+            {
+                OriginalCardId = originalCard.GetIdentifier(),
+                NewCardId = newCard.ProgramCardId
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync(x => x.Discriminator == TransactionLogDiscriminator.TransferFundTransactionLog);
+
+            transactionLog.Discriminator.Should().Be(TransactionLogDiscriminator.TransferFundTransactionLog);
+            transactionLog.FundTransferredFromProgramCardId.Should().Be(originalCard.ProgramCardId);
+            transactionLog.CardProgramCardId.Should().Be(newCard.ProgramCardId);
+            transactionLog.ProjectId.Should().Be(project.Id);
         }
 
         [Fact]

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiaryTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiaryTest.cs
@@ -190,6 +190,30 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Cards
         }
 
         [Fact]
+        public async Task UnassignCardToBeneficiaryCreatesTransactionLogWithCorrectFields()
+        {
+            var input = new UnassignCardFromBeneficiary.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                CardId = card.GetIdentifier()
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync(x =>
+                x.Discriminator == TransactionLogDiscriminator.RefundBudgetAllowanceFromUnassignedCardTransactionLog
+                && x.SubscriptionId == subscription1.Id);
+
+            transactionLog.TotalAmount.Should().Be(50);
+            transactionLog.BeneficiaryId.Should().Be(beneficiary.Id);
+            transactionLog.BeneficiaryFirstname.Should().Be(beneficiary.Firstname);
+            transactionLog.BeneficiaryLastname.Should().Be(beneficiary.Lastname);
+            transactionLog.OrganizationId.Should().Be(organization.Id);
+            transactionLog.SubscriptionId.Should().Be(subscription1.Id);
+            transactionLog.ProjectId.Should().Be(project.Id);
+        }
+
+        [Fact]
         public async Task ThrowsIfBeneficiaryNotFound()
         {
             var input = new UnassignCardFromBeneficiary.Input()

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscriptionTest.cs
@@ -29,16 +29,18 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         private readonly IRequestHandler<RemoveBeneficiaryFromSubscription.Input> handler;
         private readonly Subscription subscription;
         private readonly Beneficiary beneficiary;
+        private readonly Organization organization;
+        private readonly Project project;
 
         public RemoveBeneficiaryFromSubscriptionTest()
         {
-            var project = new Project()
+            project = new Project()
             {
                 Name = "Project 1"
             };
             DbContext.Projects.Add(project);
 
-            var organization = new Organization()
+            organization = new Organization()
             {
                 Name = "Organization 1",
                 Project = project
@@ -289,6 +291,31 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
             // totalRefund = 2 * 25 = 50
             localBudgetAllowance.AvailableFund.Should().Be(75);
             transactionLogCreated.Should().Be(true);
+        }
+
+        [Fact]
+        public async Task RemoveBeneficiaryFromSubscriptionCreatesTransactionLogWithCorrectFields()
+        {
+            var input = new RemoveBeneficiaryFromSubscription.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier()
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync(x =>
+                x.Discriminator == TransactionLogDiscriminator.RefundBudgetAllowanceFromRemovedBeneficiaryFromSubscriptionTransactionLog);
+
+            transactionLog.TotalAmount.Should().Be(25);
+            transactionLog.BeneficiaryId.Should().Be(beneficiary.Id);
+            transactionLog.BeneficiaryFirstname.Should().Be(beneficiary.Firstname);
+            transactionLog.BeneficiaryLastname.Should().Be(beneficiary.Lastname);
+            transactionLog.OrganizationId.Should().Be(organization.Id);
+            transactionLog.OrganizationName.Should().Be(organization.Name);
+            transactionLog.SubscriptionId.Should().Be(subscription.Id);
+            transactionLog.SubscriptionName.Should().Be(subscription.Name);
+            transactionLog.ProjectId.Should().Be(project.Id);
         }
 
         [Fact]

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddLoyaltyFundToCardTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddLoyaltyFundToCardTest.cs
@@ -97,6 +97,29 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
         }
 
         [Fact]
+        public async Task AddLoyaltyFundToCardCreatesTransactionLogWithCorrectFields()
+        {
+            var input = new AddLoyaltyFundToCard.Input()
+            {
+                ProjectId = project.GetIdentifier(),
+                CardId = card.ProgramCardId,
+                Amount = 10
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transaction = await DbContext.Transactions.OfType<LoyaltyAddingFundTransaction>().FirstAsync();
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync(x => x.TransactionUniqueId == transaction.TransactionUniqueId);
+
+            transactionLog.Discriminator.Should().Be(TransactionLogDiscriminator.LoyaltyAddingFundTransactionLog);
+            transactionLog.TotalAmount.Should().Be(10);
+            transactionLog.CardProgramCardId.Should().Be(card.ProgramCardId);
+            transactionLog.BeneficiaryId.Should().Be(beneficiary.Id);
+            transactionLog.OrganizationId.Should().Be(organization.Id);
+            transactionLog.ProjectId.Should().Be(project.Id);
+        }
+
+        [Fact]
         public async Task ThrowsIfCardNotFoundExceptiond()
         {
             var input = new AddLoyaltyFundToCard.Input()

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/CreateManuallyAddingFundTransactionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/CreateManuallyAddingFundTransactionTest.cs
@@ -264,6 +264,35 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
         }
 
         [Fact]
+        public async Task CreateTransactionManuallyCreatesTransactionLogWithCorrectFields()
+        {
+            var input = new CreateManuallyAddingFundTransaction.Input()
+            {
+                Amount = 10,
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                ProductGroupId = productGroup.GetIdentifier()
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transaction = await DbContext.Transactions.FirstAsync();
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync(x => x.TransactionUniqueId == transaction.TransactionUniqueId);
+
+            transactionLog.Discriminator.Should().Be(TransactionLogDiscriminator.ManuallyAddingFundTransactionLog);
+            transactionLog.TotalAmount.Should().Be(10);
+            transactionLog.BeneficiaryId.Should().Be(beneficiary.Id);
+            transactionLog.BeneficiaryFirstname.Should().Be(beneficiary.Firstname);
+            transactionLog.BeneficiaryLastname.Should().Be(beneficiary.Lastname);
+            transactionLog.BeneficiaryIsOffPlatform.Should().Be(false);
+            transactionLog.OrganizationId.Should().Be(organization.Id);
+            transactionLog.OrganizationName.Should().Be(organization.Name);
+            transactionLog.SubscriptionId.Should().Be(subscription.Id);
+            transactionLog.SubscriptionName.Should().Be(subscription.Name);
+            transactionLog.ProjectId.Should().Be(project.Id);
+        }
+
+        [Fact]
         public async Task ThrowsIfBeneficiaryNotFound()
         {
             var input = new CreateManuallyAddingFundTransaction.Input()

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/CreateTransactionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/CreateTransactionTest.cs
@@ -36,6 +36,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
         private readonly Project project;
         private readonly Project offPlatformProject;
         private readonly CashRegister cashRegister;
+        private readonly MarketGroup marketGroup;
         private readonly Card card;
         private readonly Card offPlatformCard;
         private readonly Beneficiary beneficiary;
@@ -71,7 +72,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
                 CashRegisters = new List<CashRegister>()
             };
 
-            var marketGroup = new MarketGroup()
+            marketGroup = new MarketGroup()
             {
                 Name = "Market group 1",
                 Project = project,
@@ -724,6 +725,45 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<CreateTransaction.NotEnoughtFundException>();
+        }
+
+        [Fact]
+        public async Task CreateTransactionCreatesTransactionLogWithCorrectFields()
+        {
+            SetupRequestHandler(new VerifyCardCanBeUsedInMarket(DbContext));
+
+            var input = new CreateTransaction.Input()
+            {
+                MarketId = market.GetIdentifier(),
+                Transactions = new List<CreateTransaction.TransactionInput>(),
+                CardId = card.GetIdentifier(),
+                CashRegisterId = cashRegister.GetIdentifier()
+            };
+            input.Transactions.Add(new CreateTransaction.TransactionInput()
+            {
+                Amount = 10,
+                ProductGroupId = productGroup.GetIdentifier()
+            });
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transaction = await DbContext.Transactions.OfType<PaymentTransaction>().FirstAsync();
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync();
+
+            transactionLog.TransactionUniqueId.Should().Be(transaction.TransactionUniqueId);
+            transactionLog.Discriminator.Should().Be(TransactionLogDiscriminator.PaymentTransactionLog);
+            transactionLog.TotalAmount.Should().Be(10);
+            transactionLog.MarketId.Should().Be(market.Id);
+            transactionLog.MarketName.Should().Be(market.Name);
+            transactionLog.CashRegisterId.Should().Be(cashRegister.Id);
+            transactionLog.CashRegisterName.Should().Be(cashRegister.Name);
+            transactionLog.MarketGroupId.Should().Be(marketGroup.Id);
+            transactionLog.MarketGroupName.Should().Be(marketGroup.Name);
+            transactionLog.BeneficiaryId.Should().Be(beneficiary.Id);
+            transactionLog.BeneficiaryFirstname.Should().Be(beneficiary.Firstname);
+            transactionLog.BeneficiaryLastname.Should().Be(beneficiary.Lastname);
+            transactionLog.OrganizationId.Should().Be(organization.Id);
+            transactionLog.ProjectId.Should().Be(project.Id);
         }
     }
 }

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/EditLoyaltyFundOnCardTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/EditLoyaltyFundOnCardTest.cs
@@ -158,6 +158,26 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
         }
 
         [Fact]
+        public async Task EditLoyaltyFundOnCardCreatesTransactionLogWithCorrectFields()
+        {
+            var input = new EditLoyaltyFundOnCard.Input()
+            {
+                CardId = card.GetIdentifier(),
+                Amount = 20
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transaction = await DbContext.Transactions.OfType<LoyaltyEditFundTransaction>().FirstAsync();
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync(x => x.TransactionUniqueId == transaction.TransactionUniqueId);
+
+            transactionLog.Discriminator.Should().Be(TransactionLogDiscriminator.LoyaltyEditFundTransactionLog);
+            transactionLog.TotalAmount.Should().Be(10);
+            transactionLog.CardProgramCardId.Should().Be(card.ProgramCardId);
+            transactionLog.ProjectId.Should().Be(project.Id);
+        }
+
+        [Fact]
         public async Task ThrowsIfLoyaltyFundCantBeNegativeException()
         {
             var input = new EditLoyaltyFundOnCard.Input()

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/RefundTransactionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/RefundTransactionTest.cs
@@ -2,6 +2,8 @@
 using Moq;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.DbModel.Entities.Cards;
+using Sig.App.Backend.DbModel.Entities.CashRegisters;
+using Sig.App.Backend.DbModel.Entities.MarketGroups;
 using Sig.App.Backend.DbModel.Entities.Markets;
 using Sig.App.Backend.DbModel.Entities.Organizations;
 using Sig.App.Backend.DbModel.Entities.ProductGroups;
@@ -43,6 +45,9 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
 
         private readonly PaymentTransaction initialPaymentTransaction1;
         private readonly PaymentTransaction initialPaymentTransaction2;
+
+        private readonly CashRegister cashRegister;
+        private readonly MarketGroup marketGroup;
 
         private readonly ProductGroup productGroup;
         private readonly ProductGroup loyaltyProductgroup;
@@ -193,6 +198,29 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
                 ProductGroup = productGroup
             };
 
+            marketGroup = new MarketGroup()
+            {
+                Name = "Market group 1",
+                Project = project,
+                Markets = new List<MarketGroupMarket>(),
+                CashRegisters = new List<CashRegisterMarketGroup>()
+            };
+
+            cashRegister = new CashRegister()
+            {
+                Name = "Cash register 1",
+                Market = market,
+                MarketGroups = new List<CashRegisterMarketGroup>()
+            };
+
+            var cashRegisterMarketGroup = new CashRegisterMarketGroup()
+            {
+                CashRegister = cashRegister,
+                MarketGroup = marketGroup
+            };
+            marketGroup.CashRegisters.Add(cashRegisterMarketGroup);
+            cashRegister.MarketGroups.Add(cashRegisterMarketGroup);
+
             initialPaymentTransaction1 = new PaymentTransaction()
             {
                 Amount = 20,
@@ -200,6 +228,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
                 Beneficiary = beneficiary,
                 Market = market,
                 Organization = organization,
+                CashRegister = cashRegister,
                 TransactionByProductGroups = new List<PaymentTransactionProductGroup>()
                 {
                     new PaymentTransactionProductGroup()
@@ -278,6 +307,8 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
             project.Organizations = new List<Organization>() { organization };
             project.Cards = new List<Card> { card };
 
+            DbContext.MarketGroups.Add(marketGroup);
+            DbContext.CashRegisters.Add(cashRegister);
             DbContext.Markets.Add(market);
             DbContext.Cards.Add(card);
             DbContext.Beneficiaries.Add(beneficiary);
@@ -666,6 +697,40 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<Backend.Requests.Commands.Mutations.Transactions.RefundTransaction.MarketDisabledException>();
+        }
+
+        [Fact]
+        public async Task CreateRefundTransactionCreatesTransactionLogWithCorrectFields()
+        {
+            var input = new Backend.Requests.Commands.Mutations.Transactions.RefundTransaction.Input()
+            {
+                InitialTransactionId = initialPaymentTransaction1.GetIdentifier(),
+                Transactions = new List<Backend.Requests.Commands.Mutations.Transactions.RefundTransaction.RefundTransactionsInput>(),
+                Password = "Abcd1234!!"
+            };
+            input.Transactions.Add(new Backend.Requests.Commands.Mutations.Transactions.RefundTransaction.RefundTransactionsInput()
+            {
+                Amount = 10,
+                ProductGroupId = productGroup.GetIdentifier()
+            });
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transactionLog = await DbContext.TransactionLogs.FirstAsync();
+
+            transactionLog.Discriminator.Should().Be(TransactionLogDiscriminator.RefundPaymentTransactionLog);
+            transactionLog.TotalAmount.Should().Be(10);
+            transactionLog.MarketId.Should().Be(market.Id);
+            transactionLog.MarketName.Should().Be(market.Name);
+            transactionLog.CashRegisterId.Should().Be(cashRegister.Id);
+            transactionLog.CashRegisterName.Should().Be(cashRegister.Name);
+            transactionLog.MarketGroupId.Should().Be(marketGroup.Id);
+            transactionLog.MarketGroupName.Should().Be(marketGroup.Name);
+            transactionLog.BeneficiaryId.Should().Be(beneficiary.Id);
+            transactionLog.BeneficiaryFirstname.Should().Be(beneficiary.Firstname);
+            transactionLog.BeneficiaryLastname.Should().Be(beneficiary.Lastname);
+            transactionLog.OrganizationId.Should().Be(organization.Id);
+            transactionLog.ProjectId.Should().Be(project.Id);
         }
     }
 }


### PR DESCRIPTION
### [JIRA - Inclure le Groupe de commerces dans les rapports de transactions exportés #195](https://sigmund-ca.atlassian.net/browse/CRCL-2378)

Cette branche ajoute le champ **MarketGroup** aux **TransactionLogs** afin d’inclure cette information dans les rapports de transactions exportés.

À ce stade, aucune migration de données historique n’est incluse pour les **TransactionLogs** déjà existants. Une validation est en cours avec Liam pour déterminer si une migration rétroactive des données est requise.

Le principal enjeu d’une migration rétroactive est le suivant : la valeur de **MarketGroup** utilisée aujourd’hui pourrait être appliquée à des transactions passées, alors que ce groupe a potentiellement changé depuis, ce qui pourrait introduire des incohérences dans les données historiques.