### PR TITLE
Fix issue with possible overrideMaxPayment too high, the user can't received more then the available date of versement

### DIFF
--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
@@ -61,6 +61,11 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             return Math.Min(maxNumberOfPayments - transactions.Count(), subscriptionPaymentRemaining);
         }
 
+        public async Task<int> AvailablePaymentRemaining(IAppUserContext ctx, [Inject] IClock clock)
+        {
+            return subscription.GetCardPaymentRemaining(clock);
+        }
+
         public int MaxNumberOfPayments()
         {
             return subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();

--- a/Sig.App.Backend/Helpers/SubscriptionHelper.cs
+++ b/Sig.App.Backend/Helpers/SubscriptionHelper.cs
@@ -30,7 +30,7 @@ namespace Sig.App.Backend.Helpers
             return Math.Max(0, subscription.IsSubscriptionPaymentBasedCardUsage ? Math.Min(cardPaymentRemaining, subscription.MaxNumberOfPayments.Value) : cardPaymentRemaining);
         }
 
-        private static int GetCardPaymentRemaining(this Subscription subscription, IClock clock)
+        public static int GetCardPaymentRemaining(this Subscription subscription, IClock clock)
         {
             var cardPaymentRemaining = 0;
             var today = clock

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using NodaTime;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.DbModel.Entities.Subscriptions;
@@ -20,11 +21,13 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
     {
         private readonly ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger;
         private readonly AppDbContext db;
+        private readonly IClock clock;
 
-        public ChangeBeneficiarySubscriptionMaxNumberOfPayments(ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger, AppDbContext db)
+        public ChangeBeneficiarySubscriptionMaxNumberOfPayments(ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger, AppDbContext db, IClock clock)
         {
             this.logger = logger;
             this.db = db;
+            this.clock = clock;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -48,7 +51,14 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             var subscription = subscriptionBeneficiary.Subscription;
+            var paymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
             var currentMax = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
+
+            if (paymentRemaining < request.MaxNumberOfPayments)
+            {
+                logger.LogWarning("[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - EffectiveMaxNumberOfPaymentsIsLowerThanOverrideException");
+                throw new EffectiveMaxNumberOfPaymentsIsLowerThanOverrideException();
+            }
 
             if (request.MaxNumberOfPayments <= currentMax)
             {
@@ -93,5 +103,6 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
         public class BeneficiaryNotInSubscriptionException : RequestValidationException { }
         public class MaxNumberOfPaymentsMustBeGreaterThanCurrentException : RequestValidationException { }
         public class NotEnoughBudgetAllowanceException : RequestValidationException { }
+        public class EffectiveMaxNumberOfPaymentsIsLowerThanOverrideException : RequestValidationException { }
     }
 }

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPaymentsTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPaymentsTest.cs
@@ -79,7 +79,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 StartDate = new DateTime(today.Year, today.Month, 1),
                 EndDate = new DateTime(today.Year, today.Month, 1).AddMonths(6),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
-                IsSubscriptionPaymentBasedCardUsage = true,
+                IsSubscriptionPaymentBasedCardUsage = false,
                 MaxNumberOfPayments = 3,
                 Types = new List<SubscriptionType>()
                 {
@@ -116,7 +116,8 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             handler = new ChangeBeneficiarySubscriptionMaxNumberOfPayments(
                 NullLogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments>.Instance,
-                DbContext);
+                DbContext,
+                Clock);
         }
 
         [Fact]
@@ -143,14 +144,14 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         [Fact]
         public async Task IncreaseFromExistingOverrideDeductsOnlyDifference()
         {
-            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 5;
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 4;
             DbContext.SaveChanges();
 
             var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
             {
                 BeneficiaryId = beneficiary.GetIdentifier(),
                 SubscriptionId = subscription.GetIdentifier(),
-                MaxNumberOfPayments = 7
+                MaxNumberOfPayments = 5
             };
 
             await handler.Handle(input, CancellationToken.None);
@@ -159,9 +160,9 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 .Include(x => x.BudgetAllowance)
                 .FirstAsync(x => x.BeneficiaryId == beneficiary.Id && x.SubscriptionId == subscription.Id);
 
-            // 7 - 5 = 2 additional payments * 50 = 100 deducted
-            localSubscriptionBeneficiary.MaxNumberOfPaymentsOverride.Should().Be(7);
-            localSubscriptionBeneficiary.BudgetAllowance.AvailableFund.Should().Be(400);
+            // 5 - 4 = 1 additional payment * 50 = 50 deducted
+            localSubscriptionBeneficiary.MaxNumberOfPaymentsOverride.Should().Be(5);
+            localSubscriptionBeneficiary.BudgetAllowance.AvailableFund.Should().Be(450);
         }
 
         [Fact]
@@ -255,6 +256,20 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.NotEnoughBudgetAllowanceException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfEffectiveMaxNumberOfPaymentsIsLowerThanOverride()
+        {
+            var input = new ChangeBeneficiarySubscriptionMaxNumberOfPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionId = subscription.GetIdentifier(),
+                MaxNumberOfPayments = 7 // exceeds the 6 calendar payment slots remaining
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<ChangeBeneficiarySubscriptionMaxNumberOfPayments.EffectiveMaxNumberOfPaymentsIsLowerThanOverrideException>();
         }
     }
 }

--- a/Sig.App.Frontend/src/views/beneficiary/ChangeMaxNumberOfPayments.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ChangeMaxNumberOfPayments.vue
@@ -10,6 +10,7 @@
     "budget-allowance-available": "Remaining budget allowance after change: {amount}",
     "success-notification": "The maximum number of payments has been updated successfully.",
     "must-be-greater-than-current": "Must be greater than the current maximum ({current})",
+    "must-not-exceed-payment-remaining": "Must not exceed the number of potential remaining versements ({remaining})",
     "must-be-a-number": "Must be a valid number"
   },
   "fr": {
@@ -22,6 +23,7 @@
     "budget-allowance-available": "Enveloppe restante après modification : {amount}",
     "success-notification": "Le nombre maximum de paiements a été mis à jour avec succès.",
     "must-be-greater-than-current": "Doit être supérieur au maximum actuel ({current})",
+    "must-not-exceed-payment-remaining": "Ne doit pas dépasser le nombre potentiel de versements restants ({remaining})",
     "must-be-a-number": "Doit être un nombre valide"
   }
 }
@@ -82,6 +84,7 @@ const newMaxNumberOfPayments = ref(0);
 
 const validationSchema = computed(() => {
   const currentMax = selectedSubscriptionData.value?.currentMax ?? 0;
+  const availablePaymentRemaining = selectedSubscriptionData.value?.availablePaymentRemaining ?? Infinity;
   return object({
     subscription: string().label(t("select-subscription-label")).required(),
     maxNumberOfPayments: number()
@@ -90,6 +93,7 @@ const validationSchema = computed(() => {
       .required()
       .integer()
       .min(currentMax + 1, t("must-be-greater-than-current", { current: currentMax }))
+      .max(availablePaymentRemaining, t("must-not-exceed-payment-remaining", { remaining: availablePaymentRemaining }))
   });
 });
 
@@ -107,6 +111,8 @@ const { result: resultBeneficiary, loading } = useQuery(
           }
           beneficiarySubscriptions {
             maxNumberOfPayments
+            paymentRemaining
+            availablePaymentRemaining
             subscription {
               id
               name
@@ -146,6 +152,8 @@ const subscriptionOptions = useResult(resultBeneficiary, [], (data) => {
       label: subscriptionName(x.subscription),
       value: x.subscription.id,
       currentMax: x.maxNumberOfPayments,
+      paymentRemaining: x.paymentRemaining,
+      availablePaymentRemaining: x.availablePaymentRemaining,
       types: x.subscription.types,
       budgetAllowance:
         x.subscription.budgetAllowances.find((b) => b.organization.id === data.beneficiary.organization.id)?.availableFund ?? 0


### PR DESCRIPTION
## Résumé
Ce correctif adresse une incohérence entre l'enveloppe budgétaire débitée et le nombre réel de versements pouvant encore avoir lieu lorsqu'on augmente le nombre maximum de paiements d'un bénéficiaire dans un abonnement.

## Problème
Il était possible de définir un MaxNumberOfPaymentsOverride supérieur au nombre de versements restants dans le calendrier de l'abonnement. Cela entraînait une déduction sur l'enveloppe budgétaire pour des versements qui n'auraient jamais lieu, créant ainsi un écart entre les fonds réservés et les fonds effectivement utilisés.

## Changements
### Backend — ChangeBeneficiarySubscriptionMaxNumberOfPayments
- Ajout d'une validation : si le nombre de versements demandé dépasse paymentRemaining (versements restants selon le calendrier et les transactions déjà effectuées), une exception EffectiveMaxNumberOfPaymentsIsLowerThanOverrideException est levée

### Tests backend
- Correction du flag IsSubscriptionPaymentBasedCardUsage à false pour tester le comportement avec un abonnement basé sur le calendrier (cas où la contrainte temporelle s'applique)
- Ajustement des valeurs du test IncreaseFromExistingOverrideDeductsOnlyDifference pour correspondre à la logique corrigée
- Ajout du test ThrowsIfEffectiveMaxNumberOfPaymentsIsLowerThanOverride

### Frontend — ChangeMaxNumberOfPayments.vue
- Ajout d'une règle de validation Yup (.max) empêchant de saisir une valeur supérieure aux versements restants disponibles