### PR TITLE
Fix issue with hasMissedPayment value to fit AddMissingPayment and AddMissingPayments code

### DIFF
--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiarySubscriptionTypeGraphType.cs
@@ -71,9 +71,9 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             var subscriptionTotalPayment = subscriptionBeneficiary.GetTotalPayment();
             var subscriptionPaymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
 
-            if (subscription.MaxNumberOfPayments.HasValue)
+            if (subscriptionBeneficiary.MaxNumberOfPaymentsOverride.HasValue || subscription.MaxNumberOfPayments.HasValue)
             {
-                return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && subscription.GetFirstPaymentDateTime(clock) < clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment;
+                return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && subscription.GetFirstPaymentDateTime(clock) < clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
             }
 
             return subscription.GetExpirationDate(clock) > clock.GetCurrentInstant().ToDateTimeUtc() && transactions.Count() < subscriptionTotalPayment - subscriptionPaymentRemaining;


### PR DESCRIPTION
## Résumé
Le champ GraphQL hasMissedPayment sur BeneficiarySubscriptionTypeGraphType utilisait un seuil différent de celui appliqué par les mutations AddMissingPayment et AddMissingPayments. Cela causait une incohérence : l'interface affichait l'option d'ajout de paiement manqué pour certains bénéficiaires, mais la mutation échouait systématiquement avec une erreur SubscriptionDontHaveMissedPaymentException.

## Cause
`HasMissedPayment` comparait `transactions.Count()` contre `subscriptionTotalPayment` (le nombre total de versements sur toute la durée de l'abonnement, ex. 12), alors que les mutations rejettent dès que `transactions.Count() >= GetEffectiveMaxNumberOfPayments()` (le plafond effectif du bénéficiaire, ex. 3).
De plus, le cas où seul `MaxNumberOfPaymentsOverride` est défini (sans `MaxNumberOfPayments` au niveau de l'abonnement) n'était pas pris en compte, ce qui faisait tomber dans la mauvaise validation.