### PR TITLE
Fix issue with AssignBeneficiaryToSubscription when adding fund at the same time

### DIFF
--- a/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
+++ b/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
@@ -124,7 +124,7 @@ namespace Sig.App.Backend.BackgroundJobs
             {
                 foreach (var subscriptionBeneficiary in subscription.Beneficiaries)
                 {
-                    CreateTransaction(subscriptionBeneficiary);
+                    await CreateTransaction(subscriptionBeneficiary);
                 }
             }
 
@@ -240,17 +240,41 @@ namespace Sig.App.Backend.BackgroundJobs
 
             if (subscriptionBeneficiary == null) return;
 
-            AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, initiatedBy);
+            await AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, initiatedBy);
             await db.SaveChangesAsync();
         }
 
-        public void AddFundToExistingSubscriptionBeneficiary(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)
+        public async Task AddFundToExistingSubscriptionBeneficiary(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)
         {
-            CreateTransaction(subscriptionBeneficiary, initiatedBy);
+            await CreateTransaction(subscriptionBeneficiary, initiatedBy);
         }
 
-        private void CreateTransaction(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)
+        private async Task CreateTransaction(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)
         {
+            if (subscriptionBeneficiary.Subscription == null)
+            {
+                subscriptionBeneficiary.Subscription = await db.Subscriptions
+                    .Include(x => x.BudgetAllowances)
+                    .Include(x => x.Types).ThenInclude(x => x.ProductGroup)
+                    .FirstAsync(x => x.Id == subscriptionBeneficiary.SubscriptionId);
+            }
+
+            if (subscriptionBeneficiary.Beneficiary == null)
+            {
+                subscriptionBeneficiary.Beneficiary = await db.Beneficiaries
+                    .Include(x => x.Card).ThenInclude(x => x.Transactions)
+                    .Include(x => x.Card).ThenInclude(x => x.Funds)
+                    .Include(x => x.Organization).ThenInclude(x => x.Project)
+                    .AsSplitQuery()
+                    .FirstAsync(x => x.Id == subscriptionBeneficiary.BeneficiaryId);
+            }
+
+            if (subscriptionBeneficiary.BeneficiaryType == null && subscriptionBeneficiary.BeneficiaryTypeId.HasValue)
+            {
+                subscriptionBeneficiary.BeneficiaryType = await db.BeneficiaryTypes
+                    .FirstAsync(x => x.Id == subscriptionBeneficiary.BeneficiaryTypeId.Value);
+            }
+
             var subscription = subscriptionBeneficiary.Subscription;
             var beneficiary = subscriptionBeneficiary.Beneficiary;
             var beneficiaryType = subscriptionBeneficiary.BeneficiaryType;

--- a/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
+++ b/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
@@ -240,8 +240,13 @@ namespace Sig.App.Backend.BackgroundJobs
 
             if (subscriptionBeneficiary == null) return;
 
-            CreateTransaction(subscriptionBeneficiary, initiatedBy);
+            AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, initiatedBy);
             await db.SaveChangesAsync();
+        }
+
+        public void AddFundToExistingSubscriptionBeneficiary(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)
+        {
+            CreateTransaction(subscriptionBeneficiary, initiatedBy);
         }
 
         private void CreateTransaction(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
@@ -163,7 +163,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                         if (budgetAllowance.AvailableFund >= amount)
                         {
                             budgetAllowance.AvailableFund -= amount;
-                            addingFundToCardJob.AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, new AddingFundToCard.InitiatedBy()
+                            await addingFundToCardJob.AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, new AddingFundToCard.InitiatedBy()
                             {
                                 TransactionInitiatorId = currentUserId,
                                 TransactionInitiatorEmail = currentUser?.Email,
@@ -223,7 +223,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
                         if (replicatePaymentOnAttribution)
                         {
-                            addingFundToCardJob.AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, new AddingFundToCard.InitiatedBy()
+                            await addingFundToCardJob.AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, new AddingFundToCard.InitiatedBy()
                             {
                                 TransactionInitiatorId = currentUserId,
                                 TransactionInitiatorEmail = currentUser?.Email,

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscription.cs
@@ -56,7 +56,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             var subscriptionId = request.SubscriptionId.LongIdentifierForType<Subscription>();
-            var subscription = await db.Subscriptions.Include(x => x.Types).Include(x => x.Beneficiaries).FirstOrDefaultAsync(x => x.Id == subscriptionId, cancellationToken);
+            var subscription = await db.Subscriptions.Include(x => x.Types).ThenInclude(x => x.ProductGroup).Include(x => x.Beneficiaries).FirstOrDefaultAsync(x => x.Id == subscriptionId, cancellationToken);
 
             if (subscription == null)
             {
@@ -98,7 +98,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             AppUser currentUser = null;
             if (request.ReplicatePaymentOnAttribution)
             {
-                query = query.Include(x => x.Card);
+                query = query
+                    .Include(x => x.Card).ThenInclude(x => x.Transactions)
+                    .Include(x => x.Card).ThenInclude(x => x.Funds)
+                    .Include(x => x.Organization).ThenInclude(x => x.Project);
                 addingFundToCardJob = new AddingFundToCard(db, clock, addingFundLogger);
                 currentUserId = httpContextAccessor.HttpContext?.User.GetUserId();
                 currentUser = db.Users.Include(x => x.Profile).FirstOrDefault(x => x.Id == currentUserId);
@@ -135,13 +138,16 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                 beneficiariesWhoGetSubscriptions = beneficiaries.Length;
                 foreach (var beneficiary in beneficiaries)
                 {
-                    subscription.Beneficiaries.Add(new SubscriptionBeneficiary()
+                    var subscriptionBeneficiary = new SubscriptionBeneficiary()
                     {
                         BeneficiaryId = beneficiary.Id,
                         SubscriptionId = subscriptionId,
                         BudgetAllowanceId = budgetAllowance.Id,
-                        BeneficiaryType = beneficiary.BeneficiaryType
-                    });
+                        BeneficiaryType = beneficiary.BeneficiaryType,
+                        Beneficiary = beneficiary,
+                        Subscription = subscription
+                    };
+                    subscription.Beneficiaries.Add(subscriptionBeneficiary);
 
                     if (request.ReplicatePaymentOnAttribution && beneficiary.Card != null)
                     {
@@ -153,11 +159,11 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                             : paymentRemaining;
 
                         var amount = subscription.Types.Where(x => x.BeneficiaryTypeId == beneficiary.BeneficiaryTypeId).Sum(x => x.Amount) * beneficiaryPaymentRemaining;
-                        
+
                         if (budgetAllowance.AvailableFund >= amount)
                         {
                             budgetAllowance.AvailableFund -= amount;
-                            await addingFundToCardJob.AddFundToSpecificBeneficiary(beneficiary.GetIdentifier(), beneficiary.BeneficiaryType, subscription.GetIdentifier(), new AddingFundToCard.InitiatedBy()
+                            addingFundToCardJob.AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, new AddingFundToCard.InitiatedBy()
                             {
                                 TransactionInitiatorId = currentUserId,
                                 TransactionInitiatorEmail = currentUser?.Email,
@@ -201,20 +207,23 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
                     if (budgetAllowance.AvailableFund >= amount)
                     {
-                        subscription.Beneficiaries.Add(new SubscriptionBeneficiary()
+                        var subscriptionBeneficiary = new SubscriptionBeneficiary()
                         {
                             BeneficiaryId = beneficiary.Id,
                             SubscriptionId = subscriptionId,
                             BudgetAllowanceId = budgetAllowance.Id,
-                            BeneficiaryType = beneficiary.BeneficiaryType
-                        });
+                            BeneficiaryType = beneficiary.BeneficiaryType,
+                            Beneficiary = beneficiary,
+                            Subscription = subscription
+                        };
+                        subscription.Beneficiaries.Add(subscriptionBeneficiary);
 
                         budgetAllowance.AvailableFund -= amount;
                         beneficiariesWhoGetSubscriptions++;
 
                         if (replicatePaymentOnAttribution)
                         {
-                            await addingFundToCardJob.AddFundToSpecificBeneficiary(beneficiary.GetIdentifier(), beneficiary.BeneficiaryType, subscription.GetIdentifier(), new AddingFundToCard.InitiatedBy()
+                            addingFundToCardJob.AddFundToExistingSubscriptionBeneficiary(subscriptionBeneficiary, new AddingFundToCard.InitiatedBy()
                             {
                                 TransactionInitiatorId = currentUserId,
                                 TransactionInitiatorEmail = currentUser?.Email,

--- a/Sig.App.BackendTests/BackgroundJobs/AddingFundToCardTest.cs
+++ b/Sig.App.BackendTests/BackgroundJobs/AddingFundToCardTest.cs
@@ -464,6 +464,33 @@ namespace Sig.App.BackendTests.BackgroundJobs
         }
 
         [Fact]
+        public async Task AddFundToExistingSubscriptionBeneficiaryLoadsNavPropsWhenNull()
+        {
+            // Arrange: SubscriptionBeneficiary with only FK scalars — simulates a caller that forgot .Include()
+            var partialSb = new SubscriptionBeneficiary
+            {
+                SubscriptionId = subscription.Id,
+                BeneficiaryId = beneficiary.Id,
+                BeneficiaryTypeId = beneficiaryType.Id
+                // Subscription, Beneficiary, BeneficiaryType are intentionally null
+            };
+
+            var fundBefore = card.Funds.First().Amount;
+
+            // Act
+            await job.AddFundToExistingSubscriptionBeneficiary(partialSb);
+            await DbContext.SaveChangesAsync();
+
+            // Assert: fund was added despite null nav props (lazy-load kicked in)
+            var updatedCard = DbContext.Cards.Include(x => x.Funds).First();
+            updatedCard.Funds.First().Amount.Should().Be(fundBefore + 25);
+
+            var transaction = DbContext.Transactions.OfType<SubscriptionAddingFundTransaction>().FirstOrDefault();
+            transaction.Should().NotBeNull();
+            transaction.Amount.Should().Be(25);
+        }
+
+        [Fact]
         public async Task DontAddFundIfParticipantHaveMaxNumberOfPaymentsOverrideAndMaxNumberOfTransaction()
         {
             var today = Clock.GetCurrentInstant().ToDateTimeUtc();

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/AssignBeneficiariesToSubscriptionTest.cs
@@ -5,10 +5,12 @@ using NodaTime;
 using Sig.App.Backend.BackgroundJobs;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.DbModel.Entities.BudgetAllowances;
+using Sig.App.Backend.DbModel.Entities.Cards;
 using Sig.App.Backend.DbModel.Entities.Organizations;
 using Sig.App.Backend.DbModel.Entities.ProductGroups;
 using Sig.App.Backend.DbModel.Entities.Projects;
 using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Entities.Transactions;
 using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.Extensions;
 using Sig.App.Backend.Requests.Commands.Mutations.Subscriptions;
@@ -594,6 +596,102 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<AssignBeneficiariesToSubscription.NotEnoughBudgetAllowanceException>();
+        }
+
+        [Fact]
+        public async Task AssignSubscriptionWithReplicatePaymentOnAttributionShouldCreatesTransactionOnCard()
+        {
+            var card = new Card()
+            {
+                Status = CardStatus.Assigned,
+                Project = project,
+                Funds = new List<Fund>(),
+                Transactions = new List<Transaction>()
+            };
+            DbContext.Cards.Add(card);
+            beneficiary1.Card = card;
+            DbContext.SaveChanges();
+
+            var input = new AssignBeneficiariesToSubscription.Input()
+            {
+                OrganizationId = organization.GetIdentifier(),
+                SubscriptionId = subscription1.GetIdentifier(),
+                Beneficiaries = [beneficiary1.GetIdentifier()],
+                ReplicatePaymentOnAttribution = true
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transactions = DbContext.Transactions.OfType<SubscriptionAddingFundTransaction>().ToList();
+            transactions.Should().HaveCount(1);
+            transactions.First().Amount.Should().Be(50);
+
+            var cardFund = DbContext.Funds.First();
+            cardFund.Amount.Should().Be(50);
+
+            // Budget is reserved for all remaining + current payment (replication adds 1)
+            var localBudgetAllowance = DbContext.BudgetAllowances.First(x => x.Id == budgetAllowance1.Id);
+            localBudgetAllowance.AvailableFund.Should().Be(600);
+        }
+
+        [Fact]
+        public async Task AssignSubscriptionWithReplicatePaymentOnAttributionNoBeneficiaryCardShouldNotCreateTransaction()
+        {
+            // beneficiary1 has no card — replication should be skipped
+            var input = new AssignBeneficiariesToSubscription.Input()
+            {
+                OrganizationId = organization.GetIdentifier(),
+                SubscriptionId = subscription1.GetIdentifier(),
+                Beneficiaries = [beneficiary1.GetIdentifier()],
+                ReplicatePaymentOnAttribution = true
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transactions = DbContext.Transactions.OfType<SubscriptionAddingFundTransaction>().ToList();
+            transactions.Should().BeEmpty();
+
+            var localBudgetAllowance = DbContext.BudgetAllowances.First(x => x.Id == budgetAllowance1.Id);
+            localBudgetAllowance.AvailableFund.Should().Be(650);
+        }
+
+        [Fact]
+        public async Task AssignSubscriptionWithReplicatePaymentOnAttributionWithMultipleBeneficiariesShouldCreatesOneTransactionPerBeneficiary()
+        {
+            var card1 = new Card()
+            {
+                Status = CardStatus.Assigned,
+                Project = project,
+                Funds = new List<Fund>(),
+                Transactions = new List<Transaction>()
+            };
+            var card2 = new Card()
+            {
+                Status = CardStatus.Assigned,
+                Project = project,
+                Funds = new List<Fund>(),
+                Transactions = new List<Transaction>()
+            };
+            DbContext.Cards.AddRange(card1, card2);
+            beneficiary1.Card = card1;
+            beneficiary2.Card = card2;
+            DbContext.SaveChanges();
+
+            var input = new AssignBeneficiariesToSubscription.Input()
+            {
+                OrganizationId = organization.GetIdentifier(),
+                SubscriptionId = subscription1.GetIdentifier(),
+                Beneficiaries = [beneficiary1.GetIdentifier(), beneficiary2.GetIdentifier()],
+                ReplicatePaymentOnAttribution = true
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var transactions = DbContext.Transactions.OfType<SubscriptionAddingFundTransaction>().ToList();
+            transactions.Should().HaveCount(2);
+
+            var localBudgetAllowance = DbContext.BudgetAllowances.First(x => x.Id == budgetAllowance1.Id);
+            localBudgetAllowance.AvailableFund.Should().Be(500); // 700 - (2 × 100)
         }
     }
 }

--- a/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
@@ -85,13 +85,8 @@
       <template v-if="organizations && manageOrganizations" #right>
         <div class="flex items-center gap-x-4">
           <span class="text-sm text-primary-700" aria-hidden>{{ t("selected-organization") }}</span>
-          <PfFormInputSelect
-            id="selectedOrganization"
-            has-hidden-label
-            col-span-class="sm:col-span-3"
-            :label="t('selected-organization')"
-            :value="selectedOrganization"
-            :options="organizations"
+          <PfFormInputSelect id="selectedOrganization" has-hidden-label col-span-class="sm:col-span-3"
+            :label="t('selected-organization')" :value="selectedOrganization" :options="organizations"
             @input="onOrganizationSelected" />
         </div>
       </template>
@@ -99,27 +94,15 @@
         <div class="sm:ml-6 flex flex-right gap-x-4 gap-y-3 justify-end">
           <div class="flex items-center gap-x-4">
             <span class="text-sm text-primary-700" aria-hidden>{{ t("selected-subscription") }}</span>
-            <PfFormInputSelect
-              id="selectedSubscription"
-              has-hidden-label
-              col-span-class="sm:col-span-3"
-              :label="t('selected-subscription')"
-              :value="selectedSubscription"
-              :options="subscriptions"
+            <PfFormInputSelect id="selectedSubscription" has-hidden-label col-span-class="sm:col-span-3"
+              :label="t('selected-subscription')" :value="selectedSubscription" :options="subscriptions"
               @input="onSubscriptionSelected" />
           </div>
           <div class="flex items-center gap-x-4">
             <span class="text-sm text-primary-700" aria-hidden>{{ t("max-allocation") }}</span>
-            <PfFormInputText
-              id="maxAllocation"
-              has-hidden-label
-              input-type="number"
-              input-mode="decimal"
-              col-span-class="sm:col-span-3"
-              :disabled="isMaxAllocationInputDisabled"
-              :label="t('max-allocation')"
-              :value="maxAllocation"
-              @input="updateMaxAllocation">
+            <PfFormInputText id="maxAllocation" has-hidden-label input-type="number" input-mode="decimal"
+              col-span-class="sm:col-span-3" :disabled="isMaxAllocationInputDisabled" :label="t('max-allocation')"
+              :value="maxAllocation" @input="updateMaxAllocation">
               <template #trailingIcon>
                 <UiDollarSign />
               </template>
@@ -127,52 +110,37 @@
           </div>
           <div class="flex items-center">
             <template v-if="isMaxAllocationInputDisabled">
-              <PfButtonAction
-                class="pf-button px-0 border-primary-700 border rounded-r-none"
+              <PfButtonAction class="pf-button px-0 border-primary-700 border rounded-r-none"
                 :class="!isRandomized ? 'cursor-default bg-green-300 text-white' : 'hover:bg-primary-700 hover:text-white'"
-                type="button"
-                :disabled="isMaxAllocationInputDisabled"
-                :title="t('chronological-order')"
+                type="button" :disabled="isMaxAllocationInputDisabled" :title="t('chronological-order')"
                 @click="isRandomized = false">
                 <PfIcon :icon="SortIcon" size="lg" />
                 <span class="sr-only">{{ t("sort") }}</span>
               </PfButtonAction>
-              <PfButtonAction
-                class="pf-button px-0 border-primary-700 border rounded-l-none border-l-0"
+              <PfButtonAction class="pf-button px-0 border-primary-700 border rounded-l-none border-l-0"
                 :class="isRandomized ? 'cursor-default bg-green-300 text-white' : 'hover:bg-primary-700 hover:text-white'"
-                type="button"
-                :disabled="isMaxAllocationInputDisabled"
-                :title="t('random-order')"
+                type="button" :disabled="isMaxAllocationInputDisabled" :title="t('random-order')"
                 @click="isRandomized = true">
                 <PfIcon :icon="RandomIcon" size="lg" />
                 <span class="sr-only">{{ t("randomize") }}</span>
               </PfButtonAction>
             </template>
             <template v-else>
-              <button
-                class="pf-button px-0 border-primary-700 border rounded-r-none"
+              <button class="pf-button px-0 border-primary-700 border rounded-r-none"
                 :class="!isRandomized ? 'cursor-default bg-green-300 text-white' : 'hover:bg-primary-700 hover:text-white'"
-                type="button"
-                :title="t('chronological-order')"
-                @click="isRandomized = false">
+                type="button" :title="t('chronological-order')" @click="isRandomized = false">
                 <PfIcon :icon="SortIcon" size="lg" />
                 <span class="sr-only">{{ t("sort") }}</span>
               </button>
-              <button
-                class="pf-button px-0 border-primary-700 border rounded-l-none border-l-0"
+              <button class="pf-button px-0 border-primary-700 border rounded-l-none border-l-0"
                 :class="isRandomized ? 'cursor-default bg-green-300 text-white' : 'hover:bg-primary-700 hover:text-white'"
-                type="button"
-                :title="t('random-order')"
-                @click="isRandomized = true">
+                type="button" :title="t('random-order')" @click="isRandomized = true">
                 <PfIcon :icon="RandomIcon" size="lg" />
                 <span class="sr-only">{{ t("randomize") }}</span>
               </button>
             </template>
           </div>
-          <PfButtonAction
-            btn-style="primary"
-            :disabled="isAutoSelectBtnDisabled"
-            :label="t('auto-select-participants')"
+          <PfButtonAction btn-style="primary" :disabled="isAutoSelectBtnDisabled" :label="t('auto-select-participants')"
             @click="onAutoSelect" />
         </div>
       </template>
@@ -187,67 +155,43 @@
           </p>
         </div>
         <div class="lg:flex lg:items-center">
-          <BeneficiaryFilters
-            v-if="selectedOrganization !== ''"
-            v-model="searchInput"
-            hide-conflict-filter
-            hide-card-is-disabled-filter
-            hide-sort-order
-            :available-beneficiary-types="availableBeneficiaryTypes"
-            :available-subscriptions="availableSubscriptions"
-            :selected-beneficiary-types="beneficiaryTypesFilter"
-            :selected-subscriptions="subscriptionsFilter"
-            :selected-status="status"
-            :selected-card-status="cardStatus"
-            :without-subscription-id="WITHOUT_SUBSCRIPTION"
-            :beneficiary-status-inactive="BENEFICIARY_STATUS_INACTIVE"
-            :beneficiary-status-active="BENEFICIARY_STATUS_ACTIVE"
-            :card-status-with="BENEFICIARY_WITH_CARD"
-            :card-status-without="BENEFICIARY_WITHOUT_CARD"
-            :search-filter="searchText"
+          <BeneficiaryFilters v-if="selectedOrganization !== ''" v-model="searchInput" hide-conflict-filter
+            hide-card-is-disabled-filter hide-sort-order :available-beneficiary-types="availableBeneficiaryTypes"
+            :available-subscriptions="availableSubscriptions" :selected-beneficiary-types="beneficiaryTypesFilter"
+            :selected-subscriptions="subscriptionsFilter" :selected-status="status" :selected-card-status="cardStatus"
+            :without-subscription-id="WITHOUT_SUBSCRIPTION" :beneficiary-status-inactive="BENEFICIARY_STATUS_INACTIVE"
+            :beneficiary-status-active="BENEFICIARY_STATUS_ACTIVE" :card-status-with="BENEFICIARY_WITH_CARD"
+            :card-status-without="BENEFICIARY_WITHOUT_CARD" :search-filter="searchText"
             :administration-subscriptions-off-platform="administrationSubscriptionsOffPlatform"
             :beneficiaries-are-anonymous="beneficiariesAreAnonymous"
             @beneficiaryTypesUnchecked="onBeneficiaryTypesUnchecked"
-            @beneficiaryTypesChecked="onBeneficiaryTypesChecked"
-            @subscriptionsUnchecked="onSubscriptionsUnchecked"
-            @subscriptionsChecked="onSubscriptionsChecked"
-            @statusChecked="onStatusChecked"
-            @statusUnchecked="onStatusUnchecked"
-            @cardStatusChecked="onCardStatusChecked"
-            @cardStatusUnchecked="onCardStatusUnchecked"
-            @resetFilters="onResetFilters"
-            @search="onSearch" />
+            @beneficiaryTypesChecked="onBeneficiaryTypesChecked" @subscriptionsUnchecked="onSubscriptionsUnchecked"
+            @subscriptionsChecked="onSubscriptionsChecked" @statusChecked="onStatusChecked"
+            @statusUnchecked="onStatusUnchecked" @cardStatusChecked="onCardStatusChecked"
+            @cardStatusUnchecked="onCardStatusUnchecked" @resetFilters="onResetFilters" @search="onSearch" />
         </div>
       </div>
 
       <div v-if="selectedOrganization !== '' && beneficiaries.length > 0" class="flex flex-col relative mb-6">
-        <BeneficiaryTable
-          show-associated-card
-          :beneficiaries="beneficiaries"
-          :beneficiaries-are-anonymous="beneficiariesAreAnonymous"
-          :subscriptions="subscriptions"
-          :selected-subscription="selectedSubscription"
-          @beneficiarySelectedChecked="onSelectedBeneficiaryChecked"
+        <BeneficiaryTable show-associated-card :beneficiaries="beneficiaries"
+          :beneficiaries-are-anonymous="beneficiariesAreAnonymous" :subscriptions="subscriptions"
+          :selected-subscription="selectedSubscription" @beneficiarySelectedChecked="onSelectedBeneficiaryChecked"
           @beneficiarySelectedUnchecked="onSelectedBeneficiaryUnchecked">
         </BeneficiaryTable>
         <div
           class="sticky bottom-4 ml-auto before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
-          <PfButtonAction
-            tag="routerLink"
-            btn-style="secondary"
-            class="rounded-full"
-            :disabled="isConfirmButtonDisabled"
-            @click="onConfirmSubscription">
+          <PfButtonAction tag="routerLink" btn-style="secondary" class="rounded-full"
+            :disabled="isConfirmButtonDisabled" @click="onConfirmSubscription">
             <span class="inline-flex items-center">
               {{ t("assign-subscription-btn") }}
               <span
-                class="bg-primary-700 w-6 h-6 flex items-center justify-center rounded-full text-p3 leading-none ml-2 -mr-2"
-                >{{ selectedBeneficiaries.length }}</span
-              >
+                class="bg-primary-700 w-6 h-6 flex items-center justify-center rounded-full text-p3 leading-none ml-2 -mr-2">{{
+                selectedBeneficiaries.length }}</span>
             </span>
           </PfButtonAction>
         </div>
-        <div v-if="displayLoadMoreBeneficiaries" class="sticky items-center justify-center py-4 px-4 text-center sm:block sm:p-0">
+        <div v-if="displayLoadMoreBeneficiaries"
+          class="sticky items-center justify-center py-4 px-4 text-center sm:block sm:p-0">
           <PfButtonAction tag="routerLink" btn-style="primary" class="rounded-full" @click="onFetchMoreBeneficiaries">
             <span class="inline-flex items-center">
               {{ t("load-more-beneficiaries") }}
@@ -257,16 +201,13 @@
       </div>
 
       <UiEmptyPage v-else-if="selectedSubscription && anyFiltersActive">
-        <UiCta
-          :img-src="require('@/assets/img/participants.jpg')"
-          :description="t('no-results')"
-          :primary-btn-label="t('reset-search')"
-          primary-btn-is-action
-          @onPrimaryBtnClick="onResetFilters">
+        <UiCta :img-src="require('@/assets/img/participants.jpg')" :description="t('no-results')"
+          :primary-btn-label="t('reset-search')" primary-btn-is-action @onPrimaryBtnClick="onResetFilters">
         </UiCta>
       </UiEmptyPage>
       <UiEmptyPage v-else-if="selectedSubscription">
-        <UiCta :img-src="require('@/assets/img/participants.jpg')" :description="t('no-participants-in-subscription')"> </UiCta>
+        <UiCta :img-src="require('@/assets/img/participants.jpg')" :description="t('no-participants-in-subscription')">
+        </UiCta>
       </UiEmptyPage>
       <UiEmptyPage v-else>
         <UiCta :img-src="require('@/assets/img/participants.jpg')" :description="t('no-participants')"> </UiCta>
@@ -274,13 +215,9 @@
     </div>
   </Loading>
 
-  <UiDialogWarningModal
-    v-if="displayConfirmDialog"
-    :title="t('title-confirm')"
-    :cancel-button-label="t('cancel-confirmation')"
-    :confirm-button-label="t('submit-confirmation')"
-    :is-disabled="budgetAllowanceAvailableAfterAllocation < 0"
-    @goBack="closeConfirmDialog"
+  <UiDialogWarningModal v-if="displayConfirmDialog" :title="t('title-confirm')"
+    :cancel-button-label="t('cancel-confirmation')" :confirm-button-label="t('submit-confirmation')"
+    :is-disabled="budgetAllowanceAvailableAfterAllocation < 0" @goBack="closeConfirmDialog"
     @confirm="confirmAssignation">
     <template #description>
       <div>
@@ -293,25 +230,20 @@
           }}
         </p>
         <!-- eslint-disable vue/no-v-html @intlify/vue-i18n/no-v-html -->
-        <p
-          class="text-primary-700"
-          v-html="t('usage-amount', { amount: amountThatWillBeAllocatedModalMoneyFormat, detail: usageAmountDetail })"></p>
+        <p class="text-primary-700"
+          v-html="t('usage-amount', { amount: amountThatWillBeAllocatedModalMoneyFormat, detail: usageAmountDetail })">
+        </p>
         <!-- eslint-disable vue/no-v-html @intlify/vue-i18n/no-v-html -->
-        <p
-          :class="{
-            'text-red-500': budgetAllowanceAvailableAfterAllocation < 0,
-            'text-primary-700': budgetAllowanceAvailableAfterAllocation >= 0
-          }"
-          v-html="t('remaining-amount', { amount: budgetAllowanceAvailableAfterAllocationMoneyFormat })"></p>
-        <PfFormInputCheckbox
-          v-if="selectedSubscriptionHasMissedPayment && selectedBeneficiariesWithCard.length > 0"
-          :label="
-            t('replicate-payment-on-attribution', {
-              totalParticipantWithCard: selectedBeneficiariesWithCard.length,
-              totalParticipant: selectedBeneficiaries.length
-            })
-          "
-          :description="t('replicate-payment-on-attribution-desc')"
+        <p :class="{
+          'text-red-500': budgetAllowanceAvailableAfterAllocation < 0,
+          'text-primary-700': budgetAllowanceAvailableAfterAllocation >= 0
+        }" v-html="t('remaining-amount', { amount: budgetAllowanceAvailableAfterAllocationMoneyFormat })"></p>
+        <PfFormInputCheckbox v-if="selectedSubscriptionHasMissedPayment && selectedBeneficiariesWithCard.length > 0"
+          :label="t('replicate-payment-on-attribution', {
+            totalParticipantWithCard: selectedBeneficiariesWithCard.length,
+            totalParticipant: selectedBeneficiaries.length
+          })
+            " :description="t('replicate-payment-on-attribution-desc')"
           @input="onReplicatePaymentOnAttributionChecked" />
       </div>
     </template>
@@ -741,7 +673,7 @@ const amountThatWillBeAllocated = computed(() => {
       paymentRemaining = Math.min(paymentRemaining, selectedSubscriptionData.maxNumberOfPayments - beneficiaryTransactionCount);
     }
 
-    if (replicatePaymentOnAttribution.value && x.card && paymentRemaining > 0) {
+    if (replicatePaymentOnAttribution.value && x.card && paymentRemaining >= 0) {
       if (selectedSubscriptionData.isSubscriptionPaymentBasedCardUsage) {
         if (selectedSubscriptionData.maxNumberOfPayments - beneficiaryTransactionCount > subscriptionPaymentRemaining) {
           paymentRemaining++;
@@ -811,8 +743,8 @@ const selectedSubscriptionHasMissedPayment = computed(() => {
   return (
     subscriptions.value.find((x) => x.value === selectedSubscription.value).hasMissedPayment &&
     subscriptions.value.find((x) => x.value === selectedSubscription.value).totalPayment -
-      subscriptions.value.find((x) => x.value === selectedSubscription.value).paymentRemaining >
-      beneficiaryTransactionCount
+    subscriptions.value.find((x) => x.value === selectedSubscription.value).paymentRemaining >
+    beneficiaryTransactionCount
   );
 });
 
@@ -825,8 +757,7 @@ const usageAmountDetail = computed(() => {
     )
     .map(
       (x) =>
-        `${x.beneficiaryType.name}: <b>${
-          selectedBeneficiaries.value.filter((y) => y.beneficiaryType.id === x.beneficiaryType.id).length
+        `${x.beneficiaryType.name}: <b>${selectedBeneficiaries.value.filter((y) => y.beneficiaryType.id === x.beneficiaryType.id).length
         }</b>`
     )
     .join(", ");
@@ -1113,39 +1044,24 @@ function onReplicatePaymentOnAttributionChecked(input) {
 .assign-subscription-list-vue {
   --pf-top-header-height: 170px;
   --pf-table-header-height: 67px;
-  --ui-table-height: calc(
-    100dvh -
-      (var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) + 2rem)
-  );
+  --ui-table-height: calc(100dvh - (var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) + 2rem));
 
   @media screen("xs") {
     --pf-top-header-height: 123px;
     --pf-table-header-height: 72px;
-    --ui-table-height: calc(
-      100dvh -
-        (var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) + 2rem)
-    );
+    --ui-table-height: calc(100dvh - (var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) + 2rem));
   }
 
   @media screen("sm") {
     --pf-top-header-height: 139px;
     --pf-table-header-height: 61px;
-    --ui-table-height: calc(
-      100dvh -
-        (var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) + 3rem)
-    );
+    --ui-table-height: calc(100dvh - (var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) + 3rem));
   }
 
   @media screen("lg") {
     --pf-top-header-height: 152px;
     --pf-table-header-height: 77px;
-    --ui-table-height: calc(
-      100dvh -
-        (
-          var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) +
-            3.6rem
-        )
-    );
+    --ui-table-height: calc(100dvh - (var(--pf-top-bar-height) + var(--pf-top-header-height) + var(--pf-table-header-height) + var(--pf-footer-height) + 3.6rem));
   }
 }
 </style>


### PR DESCRIPTION
## Problème
Lors de l'attribution d'un abonnement à un bénéficiaire avec l'option "Répliquer le paiement à l'attribution" activée, aucune transaction n'était créée sur la carte du bénéficiaire.

### La cause
AddFundToSpecificBeneficiary effectuait une requête DB pour récupérer le SubscriptionBeneficiary, mais celui-ci n'avait pas encore été sauvegarder. La méthode recevait donc null et retournait silencieusement sans créer de transaction.

## Solution
Ajout d'une nouvelle méthode AddFundToExistingSubscriptionBeneficiary dans AddingFundToCard qui accepte un SubscriptionBeneficiary et appelle CreateTransaction sans passer par la DB.

La méthode existante AddFundToSpecificBeneficiary (utilisée par AddMissingPayment et AddMissingPayments) est refactorisée pour déléguer à cette nouvelle méthode, centralisant ainsi la logique de création de transaction.

Dans AssignBeneficiariesToSubscription, les deux appel construisent maintenant le SubscriptionBeneficiary et appellent la nouvelle méthode. Un seul SaveChangesAsync est conservé à la fin du handler (aucune sauvegarde partielle en cours de traitement).

## Tests ajoutés
Trois nouveaux cas de test dans AssignBeneficiariesToSubscriptionTest :
- Avec carte : vérifie qu'une SubscriptionAddingFundTransaction est bien créée sur la carte du bénéficiaire.
- Sans carte : vérifie qu'aucune transaction n'est créée si le bénéficiaire n'a pas de carte.
- Plusieurs bénéficiaires : vérifie qu'une transaction est créée pour chaque bénéficiaire avec une carte.