### PR TITLE
Enhance AddMissingPayments mutation to conditionally deduct budget allowance based on effective max payments and remaining subscription payments.

### DIFF
--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
@@ -18,6 +18,7 @@ using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.BackgroundJobs;
 using Sig.App.Backend.DbModel.Entities.Transactions;
 using System.Collections.Generic;
+using System;
 
 namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 {
@@ -106,9 +107,11 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                 }
 
                 var transactions = await db.Transactions.OfType<SubscriptionAddingFundTransaction>()
+                    .Where(x => x.Status != DbModel.Enums.FundTransactionStatus.Unassigned)
                     .Include(x => x.SubscriptionType)
                     .Where(x => x.BeneficiaryId == beneficiary.Id && x.SubscriptionType.SubscriptionId == subscription.Id).ToListAsync();
 
+                var subscriptionPaymentRemaining = subscriptionBeneficiary.GetPaymentRemaining(clock);
                 var previousPaymentCount = subscription.GetPreviousPaymentCount(clock);
 
                 if ((subscriptionBeneficiary.MaxNumberOfPaymentsOverride.HasValue || subscription.MaxNumberOfPayments.HasValue)
@@ -123,7 +126,12 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
                     throw new SubscriptionDontHaveMissedPaymentException();
                 }
 
-                subscriptionBeneficiary.BudgetAllowance.AvailableFund -= amount;
+                var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
+                var isBudgetAllowanceAlreadyAllocated = maxNumberOfPayments - transactions.Count <= Math.Min(maxNumberOfPayments - transactions.Count(), subscriptionPaymentRemaining);
+                if (!isBudgetAllowanceAlreadyAllocated)
+                {
+                    subscriptionBeneficiary.BudgetAllowance.AvailableFund -= amount;
+                }
 
                 var addingFundToCardJob = new AddingFundToCard(db, clock, addingFundLogger);
                 await addingFundToCardJob.AddFundToSpecificBeneficiary(beneficiary.GetIdentifier(), beneficiary.BeneficiaryType, subscription.GetIdentifier(), new AddingFundToCard.InitiatedBy()

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddMissingPaymentsTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Transactions/AddMissingPaymentsTest.cs
@@ -419,7 +419,50 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Transactions
                 Subscriptions = new List<Id>() { subscription.GetIdentifier() }
             };
 
-            // override=2 > transactionCount=1, so no exception; AddMissingPayments always deducts budget
+            // override=2 > transactionCount=1, so no exception; budget already allocated
+            await handler.Handle(input, CancellationToken.None);
+
+            var localBudgetAllowance = DbContext.BudgetAllowances.First();
+            localBudgetAllowance.AvailableFund.Should().Be(100);
+        }
+
+        [Fact]
+        public async Task DeductsBudgetWhenOverrideExceedsSubscriptionPaymentsRemaining()
+        {
+            var today = Clock.GetCurrentInstant().ToDateTimeUtc();
+
+            subscription.MaxNumberOfPayments = 1;
+            subscription.StartDate = new DateTime(today.Year, today.Month, 1).AddMonths(-4);
+            subscription.EndDate = new DateTime(today.Year, today.Month, 1).AddMonths(1);
+            subscription.FundsExpirationDate = new DateTime(today.Year, today.Month, 1).AddMonths(2);
+
+            var subscriptionBeneficiary = beneficiary.Subscriptions.First();
+            subscriptionBeneficiary.MaxNumberOfPaymentsOverride = 3;
+
+            card.Transactions.Add(new SubscriptionAddingFundTransaction()
+            {
+                Amount = 25,
+                AvailableFund = 25,
+                Beneficiary = beneficiary,
+                Card = card,
+                CreatedAtUtc = Clock.GetCurrentInstant().ToDateTimeUtc(),
+                ExpirationDate = subscription.GetExpirationDate(Clock),
+                Organization = organization,
+                ProductGroup = productGroup,
+                Status = FundTransactionStatus.Actived,
+                SubscriptionType = subscription.Types.First(),
+            });
+
+            DbContext.SaveChanges();
+
+            var input = new AddMissingPayments.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                Subscriptions = new List<Id>() { subscription.GetIdentifier() }
+            };
+
+            // override=3, transactions=1, subscriptionPaymentRemaining=1
+            // remaining payments (3-1=2) > subscriptionPaymentRemaining (1): budget not pre-allocated, must be deducted
             await handler.Handle(input, CancellationToken.None);
 
             var localBudgetAllowance = DbContext.BudgetAllowances.First();


### PR DESCRIPTION
[Jelly - Montant inattendu de l'enveloppe après l'assignation à un participant](https://sigmund-ca.atlassian.net/browse/CRCL-2499)
Il y avait une différence entre la validation dans `AddMissingPayment` et `AddMissingPayments`. J'ai fait l'ajustement pour que les deux ce comporte de façon équivalente.