### PR TITLE
Consolidating the load more button into the main action area to make it visible all the time

### DIFF
--- a/Sig.App.Frontend/src/components/beneficiaries/list-beneficiaries-detailed.vue
+++ b/Sig.App.Frontend/src/components/beneficiaries/list-beneficiaries-detailed.vue
@@ -20,7 +20,7 @@
       :organization="props.organization" />
     <div
       v-if="!administrationSubscriptionsOffPlatform"
-      class="sticky bottom-4 ml-auto before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
+      class="sticky bottom-4 ml-auto before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-white/70 before:blur-lg before:rounded-full">
       <PfButtonLink
         tag="routerLink"
         :to="{ name: URL_BENEFICIARY_ASSIGN_SUBSCRIPTIONS, query: props.filteredQuery }"

--- a/Sig.App.Frontend/src/components/ui/table-no-scroll/index.vue
+++ b/Sig.App.Frontend/src/components/ui/table-no-scroll/index.vue
@@ -49,7 +49,7 @@
 
     <div
       v-if="slots.floatingActions"
-      class="sticky bottom-0 right-0 before:block before:absolute before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
+      class="sticky bottom-0 right-0 before:block before:absolute before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-white/70 before:blur-lg before:rounded-full">
       <slot name="floatingActions"></slot>
     </div>
   </div>

--- a/Sig.App.Frontend/src/components/ui/table/index.vue
+++ b/Sig.App.Frontend/src/components/ui/table/index.vue
@@ -53,7 +53,7 @@
 
     <div
       v-if="slots.floatingActions"
-      class="absolute bottom-0 right-0 before:block before:absolute before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
+      class="absolute bottom-0 right-0 before:block before:absolute before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-white/70 before:blur-lg before:rounded-full">
       <slot name="floatingActions"></slot>
     </div>
   </div>

--- a/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
@@ -179,7 +179,13 @@
           @beneficiarySelectedUnchecked="onSelectedBeneficiaryUnchecked">
         </BeneficiaryTable>
         <div
-          class="sticky bottom-4 ml-auto before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
+          class="sticky bottom-4 relative flex justify-end w-full before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
+          <PfButtonAction v-if="displayLoadMoreBeneficiaries" tag="routerLink" btn-style="primary"
+            class="rounded-full absolute left-1/2 -translate-x-1/2" @click="onFetchMoreBeneficiaries">
+            <span class="inline-flex items-center">
+              {{ t("load-more-beneficiaries") }}
+            </span>
+          </PfButtonAction>
           <PfButtonAction tag="routerLink" btn-style="secondary" class="rounded-full"
             :disabled="isConfirmButtonDisabled" @click="onConfirmSubscription">
             <span class="inline-flex items-center">
@@ -187,14 +193,6 @@
               <span
                 class="bg-primary-700 w-6 h-6 flex items-center justify-center rounded-full text-p3 leading-none ml-2 -mr-2">{{
                 selectedBeneficiaries.length }}</span>
-            </span>
-          </PfButtonAction>
-        </div>
-        <div v-if="displayLoadMoreBeneficiaries"
-          class="sticky items-center justify-center py-4 px-4 text-center sm:block sm:p-0">
-          <PfButtonAction tag="routerLink" btn-style="primary" class="rounded-full" @click="onFetchMoreBeneficiaries">
-            <span class="inline-flex items-center">
-              {{ t("load-more-beneficiaries") }}
             </span>
           </PfButtonAction>
         </div>

--- a/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
@@ -180,21 +180,23 @@
         </BeneficiaryTable>
         <div
           class="sticky bottom-4 relative flex justify-end w-full before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-white/70 before:blur-lg before:rounded-full">
-          <PfButtonAction v-if="displayLoadMoreBeneficiaries" tag="routerLink" btn-style="primary"
-            class="rounded-full absolute left-1/2 -translate-x-1/2" @click="onFetchMoreBeneficiaries">
-            <span class="inline-flex items-center">
-              {{ t("load-more-beneficiaries") }}
-            </span>
-          </PfButtonAction>
-          <PfButtonAction tag="routerLink" btn-style="secondary" class="rounded-full"
-            :disabled="isConfirmButtonDisabled" @click="onConfirmSubscription">
-            <span class="inline-flex items-center">
-              {{ t("assign-subscription-btn") }}
-              <span
-                class="bg-primary-700 w-6 h-6 flex items-center justify-center rounded-full text-p3 leading-none ml-2 -mr-2">{{
-                selectedBeneficiaries.length }}</span>
-            </span>
-          </PfButtonAction>
+          <div class="flex flex-col w-full gap-3">
+            <PfButtonAction tag="routerLink" btn-style="secondary" class="rounded-full self-end"
+              :disabled="isConfirmButtonDisabled" @click="onConfirmSubscription">
+              <span class="inline-flex items-center">
+                {{ t("assign-subscription-btn") }}
+                <span
+                  class="bg-primary-700 w-6 h-6 flex items-center justify-center rounded-full text-p3 leading-none ml-2 -mr-2">{{
+                  selectedBeneficiaries.length }}</span>
+              </span>
+            </PfButtonAction>
+            <PfButtonAction v-if="displayLoadMoreBeneficiaries" tag="routerLink" btn-style="primary"
+              class="rounded-full self-center" @click="onFetchMoreBeneficiaries">
+              <span class="inline-flex items-center">
+                {{ t("load-more-beneficiaries") }}
+              </span>
+            </PfButtonAction>
+          </div>
         </div>
       </div>
 
@@ -501,7 +503,7 @@ const {
           withoutSubscription: $withoutSubscription
           withoutSpecificSubscriptions: $withoutSpecificSubscriptions
           status: $status
-          limit: 500
+          limit: 100
           searchText: $searchText
           withCard: $withCard
           withConflictPayment: $withConflictPayment

--- a/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/AssignSubscriptions.vue
@@ -179,7 +179,7 @@
           @beneficiarySelectedUnchecked="onSelectedBeneficiaryUnchecked">
         </BeneficiaryTable>
         <div
-          class="sticky bottom-4 relative flex justify-end w-full before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
+          class="sticky bottom-4 relative flex justify-end w-full before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-white/70 before:blur-lg before:rounded-full">
           <PfButtonAction v-if="displayLoadMoreBeneficiaries" tag="routerLink" btn-style="primary"
             class="rounded-full absolute left-1/2 -translate-x-1/2" @click="onFetchMoreBeneficiaries">
             <span class="inline-flex items-center">

--- a/Sig.App.Frontend/src/views/transaction/ListTransactions.vue
+++ b/Sig.App.Frontend/src/views/transaction/ListTransactions.vue
@@ -87,7 +87,7 @@
             :total-pages="transactionLogs.totalPages" />
           <div
             v-if="canCreateTransaction"
-            class="sticky bottom-4 ml-auto before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-gradient-radial before:bg-white/70 before:blur-lg before:rounded-full">
+            class="sticky bottom-4 ml-auto before:block before:absolute before:pointer-events-none before:w-[calc(100%+50px)] before:h-[calc(100%+50px)] before:-translate-y-1/2 before:right-0 before:top-1/2 before:bg-white/70 before:blur-lg before:rounded-full">
             <PfButtonLink tag="routerLink" :to="{ name: URL_TRANSACTION_ADD }" btn-style="secondary" class="rounded-full">
               <span class="inline-flex items-center">
                 {{ t("create-transaction") }}


### PR DESCRIPTION
### [JIRA - La page d'attribution d'abonnement en masse dépasse l'écran #230](https://sigmund-ca.atlassian.net/browse/CRCL-2480)

Ajustement du bouton "Charger plus de participant-e-s" pour l'afficher en tout temps dans la page

**Avant**
<img width="1280" height="1392" alt="before" src="https://github.com/user-attachments/assets/6511ea84-55b5-4db1-9fbe-3053fd56f436" />


**Après**
<img width="1280" height="1392" alt="after" src="https://github.com/user-attachments/assets/a1c0034b-43c9-4bc1-9d9b-b13d40a7818b" />
