### PR TITLE
Fix review transaction by enhanced logic for handling undefined or null amounts in transaction calculations

### DIFF
--- a/Sig.App.Frontend/src/components/transaction/add-transaction.vue
+++ b/Sig.App.Frontend/src/components/transaction/add-transaction.vue
@@ -82,19 +82,13 @@
       </div>
       <h3 class="mb-2 mt-4">{{ t("subscriptions-title") }}</h3>
       <ul class="inline-flex flex-col justify-start items-start gap-y-1 mb-4 max-w-full">
-        <li
-          v-for="beneficiarySubscription in beneficiary.beneficiarySubscriptions"
-          :key="beneficiarySubscription.subscription.id"
-          class="mb-4">
+        <li v-for="beneficiarySubscription in beneficiary.beneficiarySubscriptions"
+          :key="beneficiarySubscription.subscription.id" class="mb-4">
           <b>{{ subscriptionName(beneficiarySubscription.subscription) }}</b>
           <!-- eslint-disable vue/no-v-html @intlify/vue-i18n/no-v-html -->
-          <div
-            v-html="
-              t('amount-received-each-payment', { amountByPayment: amountByPayment(beneficiarySubscription.subscription) })
+          <div v-html="t('amount-received-each-payment', { amountByPayment: amountByPayment(beneficiarySubscription.subscription) })
             " />
-          <div
-            v-html="
-              t('remaining-payment-on-card', { remainingPayment: beneficiarySubscription.subscription.paymentRemaining })
+          <div v-html="t('remaining-payment-on-card', { remainingPayment: beneficiarySubscription.subscription.paymentRemaining })
             " />
           <div v-html="getPaymentDates(beneficiarySubscription.subscription)" />
           <div v-html="getExpirationDate(beneficiarySubscription.subscription)" />
@@ -112,48 +106,25 @@
     }}
   </p>
   <p v-if="card && card.isDisabled" class="text-red-500 font-bold">{{ t("card-is-disabled") }}</p>
-  <Form
-    v-if="funds"
-    v-slot="{ isSubmitting, errors: formErrors }"
-    :initial-values="initialValues"
-    :validation-schema="currentSchema"
-    keep-values
-    @submit="nextStep">
+  <Form v-if="funds" v-slot="{ isSubmitting, errors: formErrors }" :initial-values="initialValues"
+    :validation-schema="currentSchema" keep-values @submit="nextStep">
     <div v-if="funds.length > 0">
-      <PfForm
-        v-if="currentStep === 0"
-        has-footer
-        footer-alt-style
-        can-cancel
-        :disable-submit="Object.keys(formErrors).length > 0 || card.isDisabled"
-        :submit-label="t('create-transaction')"
-        :cancel-label="t('cancel')"
-        :processing="isSubmitting"
-        @cancel="goToAdminTransaction">
+      <PfForm v-if="currentStep === 0" has-footer footer-alt-style can-cancel
+        :disable-submit="Object.keys(formErrors).length > 0 || card.isDisabled" :submit-label="t('create-transaction')"
+        :cancel-label="t('cancel')" :processing="isSubmitting" @cancel="goToAdminTransaction">
         <PfFormSection>
           <FieldArray v-slot="{ fields }" key-path="id" name="funds">
-            <div
-              v-for="(field, idx) in fields"
-              :key="field.key"
+            <div v-for="(field, idx) in fields" :key="field.key"
               :class="getIsGiftCard(funds[idx].fund.productGroup.name) ? 'pt-6 border-t border-grey-100' : ''">
-              <div
-                class="p-4 pt-2.5 rounded-lg"
-                :class="[
-                  getColorBgClass(funds[idx].fund.productGroup.color),
-                  getIsGiftCard(funds[idx].fund.productGroup.name) ? 'bg-diagonal-pattern' : 'dark'
-                ]">
-                <Field
-                  :id="`funds[${idx}].amount`"
-                  v-slot="{ field: inputField, errors: fieldErrors }"
+              <div class="p-4 pt-2.5 rounded-lg" :class="[
+                getColorBgClass(funds[idx].fund.productGroup.color),
+                getIsGiftCard(funds[idx].fund.productGroup.name) ? 'bg-diagonal-pattern' : 'dark'
+              ]">
+                <Field :id="`funds[${idx}].amount`" v-slot="{ field: inputField, errors: fieldErrors }"
                   :name="`funds[${idx}].amount`">
-                  <PfFormInputText
-                    :id="`funds[${idx}].amount`"
-                    class="grow"
-                    v-bind="inputField"
+                  <PfFormInputText :id="`funds[${idx}].amount`" class="grow" v-bind="inputField"
                     :label="fundLabel(funds[idx].fund, 'amount-label')"
-                    :after-label="fundAfterLabel(funds[idx].fund, 'amount-after-label')"
-                    :errors="fieldErrors"
-                    is-large
+                    :after-label="fundAfterLabel(funds[idx].fund, 'amount-after-label')" :errors="fieldErrors" is-large
                     input-mode="decimal">
                     <template #trailingIcon>
                       <UiDollarSign :errors="fieldErrors" />
@@ -165,15 +136,8 @@
           </FieldArray>
         </PfFormSection>
       </PfForm>
-      <PfForm
-        v-else
-        has-footer
-        footer-alt-style
-        :submit-label="t('confirm')"
-        :cancel-label="t('edit')"
-        can-cancel
-        :processing="isSubmitting"
-        @cancel="prevStep">
+      <PfForm v-else has-footer footer-alt-style :submit-label="t('confirm')" :cancel-label="t('edit')" can-cancel
+        :processing="isSubmitting" @cancel="prevStep">
         <PfFormSection>
           <p class="text-h1 font-bold text-primary-700 mb-0">
             {{ t("amount-charged") }}
@@ -183,17 +147,12 @@
           <div>
             <p class="mb-2 text-p3">{{ t("product-groups") }}</p>
             <ul class="mb-0 w-full">
-              <li
-                v-for="item in funds"
-                :key="item.id"
-                class="mb-2 last:mb-0 text-p2"
+              <li v-for="item in funds" :key="item.id" class="mb-2 last:mb-0 text-p2"
                 :class="getIsGiftCard(item.fund.productGroup.name) ? 'mt-6 pt-4 border-t border-grey-100' : 'dark'">
-                <div
-                  class="flex items-center w-full rounded-md py-1 px-2 text-primary-900 dark:text-white"
-                  :class="[
-                    getColorBgClass(item.fund.productGroup.color),
-                    getIsGiftCard(item.fund.productGroup.name) ? 'bg-diagonal-pattern' : ''
-                  ]">
+                <div class="flex items-center w-full rounded-md py-1 px-2 text-primary-900 dark:text-white" :class="[
+                  getColorBgClass(item.fund.productGroup.color),
+                  getIsGiftCard(item.fund.productGroup.name) ? 'bg-diagonal-pattern' : ''
+                ]">
                   <span class="w-1/2 font-bold text-lg">
                     {{ fundLabel(item.fund, "confirmation-amount-label") }}
                   </span>
@@ -208,14 +167,8 @@
       </PfForm>
     </div>
     <div v-else>
-      <PfForm
-        can-cancel
-        :disable-submit="true"
-        has-footer
-        footer-alt-style
-        :submit-label="t('create-transaction')"
-        :cancel-label="t('cancel')"
-        @cancel="goToAdminTransaction">
+      <PfForm can-cancel :disable-submit="true" has-footer footer-alt-style :submit-label="t('create-transaction')"
+        :cancel-label="t('cancel')" @cancel="goToAdminTransaction">
         <div>{{ t("no-funds-message") }}</div>
       </PfForm>
     </div>
@@ -515,6 +468,9 @@ function fundAfterLabel(fund, key) {
 function getTotalTransactionAmount() {
   let result = 0;
   for (var i = 0; i < funds.value.length; i++) {
+    if (funds.value[i].amount === undefined || funds.value[i].amount === null || funds.value[i].amount === "") {
+      continue;
+    }
     result += parseFloat(funds.value[i].amount);
   }
 
@@ -532,9 +488,9 @@ async function nextStep(values) {
     const amount = values.funds[i].amount;
     if (amount !== undefined && amount !== null && amount !== "") {
       haveAtLeastOneProductGroup = true;
-      // Convert numbers with comma as decimal separator
-      funds.value[i].amount = amount.replace(/,/, ".");
     }
+    // Convert numbers with comma as decimal separator
+    funds.value[i].amount = amount.replace(/,/, ".");
   }
 
   if (!haveAtLeastOneProductGroup) {


### PR DESCRIPTION
### [JIRA La révision d'un montant d'achat n'a pas pris effet #238](https://sigmund-ca.atlassian.net/browse/CRCL-2501)

L'édition du montant réviser ne prenait pas en considération lorsque le montant étant null ou vide (""). Maintenant, si il est vide ou null, on prend ceci en considération.