### PR TITLE
Allow editing subscription name and expiration date after beneficiaries are assigned

### DIFF
--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/EditSubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/EditSubscription.cs
@@ -7,6 +7,7 @@ using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.DbModel.Entities.ProductGroups;
 using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Entities.Transactions;
 using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.Extensions;
 using Sig.App.Backend.Gql.Bases;
@@ -14,6 +15,7 @@ using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Gql.Schema.Types;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -25,11 +27,13 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
     {
         private readonly ILogger<EditSubscription> logger;
         private readonly AppDbContext db;
+        private readonly IClock clock;
 
-        public EditSubscription(ILogger<EditSubscription> logger, AppDbContext db)
+        public EditSubscription(ILogger<EditSubscription> logger, AppDbContext db, IClock clock)
         {
             this.logger = logger;
             this.db = db;
+            this.clock = clock;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -56,16 +60,16 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                 throw new BeneficiaryTypeCanOnlyBeAssignOnce();
             }
 
-            if (db.SubscriptionBeneficiaries.Where(x => x.SubscriptionId == subscriptionId).Any())
-            {
-                logger.LogWarning("[Mutation] EditSubscription - CantEditSubscriptionWithBeneficiaries");
-                throw new CantEditSubscriptionWithBeneficiaries();
-            }
-
             if (request.StartDate > request.EndDate)
             {
                 logger.LogWarning("[Mutation] EditSubscription - EndDateMustBeAfterStartDateException");
                 throw new EndDateMustBeAfterStartDateException();
+            }
+
+            if (request.FundsExpirationDate.IsSet() && request.FundsExpirationDate.Value < LocalDate.FromDateTime(clock.GetCurrentInstant().ToDateTimeUtc()))
+            {
+                logger.LogWarning("[Mutation] EditSubscription - ExpirationDateMustBeAfterTodayDateException");
+                throw new ExpirationDateMustBeAfterTodayDateException();
             }
 
             if (request.IsSubscriptionPaymentBasedCardUsage && (!request.MaxNumberOfPayments.IsSet() || request.MaxNumberOfPayments.Value <= 0))
@@ -81,33 +85,70 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             subscription.Name = request.Name.Trim();
-            subscription.MonthlyPaymentMoment = request.MonthlyPaymentMoment;
-            subscription.StartDate = request.StartDate.AtMidnight().InUtc().ToDateTimeUtc();
-            subscription.EndDate = request.EndDate.AtMidnight().InUtc().ToDateTimeUtc();
-            subscription.FundsExpirationDate = request.FundsExpirationDate.IfSet(x => subscription.FundsExpirationDate = x.AtMidnight().InUtc().ToDateTimeUtc());
-            subscription.IsFundsAccumulable = request.IsFundsAccumulable;
-            subscription.IsSubscriptionPaymentBasedCardUsage = request.IsSubscriptionPaymentBasedCardUsage;
-            subscription.TriggerFundExpiration = request.TriggerFundExpiration;
 
-            if (request.MaxNumberOfPayments.IsSet())
+            var hasBeneficiaries = await db.SubscriptionBeneficiaries.AnyAsync(x => x.SubscriptionId == subscriptionId, cancellationToken);
+            if (hasBeneficiaries)
             {
-                subscription.MaxNumberOfPayments = request.MaxNumberOfPayments.Value;
+                if (request.FundsExpirationDate.IsSet())
+                {
+                    if (!subscription.IsFundsAccumulable || subscription.TriggerFundExpiration != FundsExpirationTrigger.SpecificDate)
+                    {
+                        logger.LogWarning("[Mutation] EditSubscription - CantEditExpirationDateException");
+                        throw new CantEditExpirationDateException();
+                    }
+                    if (!subscription.FundsExpirationDate.HasValue || subscription.IsExpired(clock))
+                    {
+                        logger.LogWarning("[Mutation] EditSubscription - ExpirationDateAlreadyPassedException");
+                        throw new ExpirationDateAlreadyPassedException();
+                    }
+                    var newExpirationDate = request.FundsExpirationDate.Value.AtMidnight().InUtc().ToDateTimeUtc();
+                    subscription.FundsExpirationDate = newExpirationDate;
+
+                    var subscriptionTypeIds = subscription.Types.Select(x => x.Id).ToList();
+                    var activeTransactions = await db.Transactions
+                        .OfType<SubscriptionAddingFundTransaction>()
+                        .Where(x => subscriptionTypeIds.Contains(x.SubscriptionTypeId) && x.Status == FundTransactionStatus.Actived)
+                        .ToListAsync(cancellationToken);
+
+                    foreach (var transaction in activeTransactions)
+                    {
+                        transaction.ExpirationDate = newExpirationDate;
+                    }
+                }
             }
             else
             {
-                subscription.MaxNumberOfPayments = null;
-            }
+                subscription.FundsExpirationDate = request.FundsExpirationDate.IsSet()
+                    ? request.FundsExpirationDate.Value.AtMidnight().InUtc().ToDateTimeUtc()
+                    : (DateTime?)null;
+                subscription.MonthlyPaymentMoment = request.MonthlyPaymentMoment;
+                subscription.StartDate = request.StartDate.AtMidnight().InUtc().ToDateTimeUtc();
+                subscription.EndDate = request.EndDate.AtMidnight().InUtc().ToDateTimeUtc();
 
-            if (request.NumberDaysUntilFundsExpire.IsSet())
-            {
-                subscription.NumberDaysUntilFundsExpire = request.NumberDaysUntilFundsExpire.Value;
-            }
-            else
-            {
-                subscription.NumberDaysUntilFundsExpire = null;
-            }
+                subscription.IsFundsAccumulable = request.IsFundsAccumulable;
+                subscription.IsSubscriptionPaymentBasedCardUsage = request.IsSubscriptionPaymentBasedCardUsage;
+                subscription.TriggerFundExpiration = request.TriggerFundExpiration;
 
-            UpdateTypes(subscription, request.Types);
+                if (request.MaxNumberOfPayments.IsSet())
+                {
+                    subscription.MaxNumberOfPayments = request.MaxNumberOfPayments.Value;
+                }
+                else
+                {
+                    subscription.MaxNumberOfPayments = null;
+                }
+
+                if (request.NumberDaysUntilFundsExpire.IsSet())
+                {
+                    subscription.NumberDaysUntilFundsExpire = request.NumberDaysUntilFundsExpire.Value;
+                }
+                else
+                {
+                    subscription.NumberDaysUntilFundsExpire = null;
+                }
+
+                UpdateTypes(subscription, request.Types);
+            }
 
             await db.SaveChangesAsync(cancellationToken);
 
@@ -166,8 +207,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
         public class SubscriptionTypesCantBeEmpty : RequestValidationException { }
         public class BeneficiaryTypeCanOnlyBeAssignOnce : RequestValidationException { }
         public class EndDateMustBeAfterStartDateException : RequestValidationException { }
-        public class CantEditSubscriptionWithBeneficiaries : RequestValidationException { }
+        public class ExpirationDateMustBeAfterTodayDateException : RequestValidationException { }
         public class MaxNumberOfPaymentsCantBeZeroException : RequestValidationException { }
         public class NumberDaysUntilFundsExpireCantBeZeroException : RequestValidationException { }
+        public class CantEditExpirationDateException : RequestValidationException { }
+        public class ExpirationDateAlreadyPassedException : RequestValidationException { }
     }
 }

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/EditSubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/EditSubscription.cs
@@ -66,7 +66,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                 throw new EndDateMustBeAfterStartDateException();
             }
 
-            if (request.FundsExpirationDate.IsSet() && request.FundsExpirationDate.Value < LocalDate.FromDateTime(clock.GetCurrentInstant().ToDateTimeUtc()))
+            if (request.FundsExpirationDate.IsSet() && request.FundsExpirationDate.Value < clock.GetCurrentInstant().InUtc().Date)
             {
                 logger.LogWarning("[Mutation] EditSubscription - ExpirationDateMustBeAfterTodayDateException");
                 throw new ExpirationDateMustBeAfterTodayDateException();

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/EditSubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/EditSubscriptionTest.cs
@@ -4,15 +4,18 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
+using Sig.App.Backend.DbModel.Entities.Cards;
 using Sig.App.Backend.DbModel.Entities.Organizations;
 using Sig.App.Backend.DbModel.Entities.ProductGroups;
 using Sig.App.Backend.DbModel.Entities.Projects;
 using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Entities.Transactions;
 using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.Extensions;
 using Sig.App.Backend.Requests.Commands.Mutations.Subscriptions;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -98,7 +101,19 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             DbContext.SaveChanges();
 
-            handler = new EditSubscription(NullLogger<EditSubscription>.Instance, DbContext);
+            handler = new EditSubscription(NullLogger<EditSubscription>.Instance, DbContext, Clock);
+        }
+
+        private Beneficiary AssignBeneficiaryToSubscription(BeneficiaryType beneficiaryType)
+        {
+            var beneficiary = new Beneficiary() { Firstname = "John", Lastname = "Doe", BeneficiaryType = beneficiaryType };
+            DbContext.Beneficiaries.Add(beneficiary);
+            subscription.Beneficiaries = new List<SubscriptionBeneficiary>()
+            {
+                new SubscriptionBeneficiary { Beneficiary = beneficiary, BeneficiaryType = beneficiaryType, Subscription = subscription }
+            };
+            DbContext.SaveChanges();
+            return beneficiary;
         }
 
         [Fact]
@@ -111,7 +126,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 Name = "Subscription 1 test",
                 StartDate = new LocalDate(2022, 2, 1),
                 EndDate = new LocalDate(2022, 4, 30),
-                FundsExpirationDate = new LocalDate(2022, 5, 1),
+                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth,
                 Types = new List<EditSubscriptionTypeInput>() { 
                     new EditSubscriptionTypeInput
@@ -131,7 +146,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
             localSubscription.MonthlyPaymentMoment.Should().Be(SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth);
             localSubscription.StartDate.Should().Be(new DateTime(2022, 2, 1));
             localSubscription.EndDate.Should().Be(new DateTime(2022, 4, 30));
-            localSubscription.FundsExpirationDate.Should().Be(new DateTime(2022, 5, 1));
+            localSubscription.FundsExpirationDate.Should().Be(new LocalDate(DateTime.UtcNow.Year + 1, 1, 1).AtMidnight().InUtc().ToDateTimeUtc());
         }
 
         [Fact]
@@ -151,31 +166,89 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         }
 
         [Fact]
-        public async Task ThrowsIfSubscriptionCantEdit()
+        public async Task CanEditNameWithBeneficiaries()
         {
-            var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync(); ;
-
-            var beneficiary = new Beneficiary()
-            {
-                Firstname = "John",
-                Lastname = "Doe",
-                Address = "123, example street",
-                Email = "john.doe@example.com",
-                Phone = "555-555-1234",
-                BeneficiaryType = localBeneficiaryType
-            };
-            DbContext.Beneficiaries.Add(beneficiary);
-
-            subscription.Beneficiaries = new List<SubscriptionBeneficiary>() { new SubscriptionBeneficiary { Beneficiary = beneficiary, BeneficiaryType = localBeneficiaryType, Subscription = subscription } };
-            DbContext.SaveChanges();
+            var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
+            AssignBeneficiaryToSubscription(localBeneficiaryType);
 
             var input = new Input()
             {
                 SubscriptionId = subscription.GetIdentifier(),
-                Name = "Subscription 1 test",
-                StartDate = new LocalDate(2022, 2, 1),
-                EndDate = new LocalDate(2022, 4, 30),
-                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth,
+                Name = "Subscription renamed",
+                StartDate = new LocalDate(2022, 1, 1),
+                EndDate = new LocalDate(2022, 3, 30),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
+                Types = new List<EditSubscriptionTypeInput>() {
+                    new EditSubscriptionTypeInput
+                    {
+                        BeneficiaryTypeId = localBeneficiaryType.GetIdentifier(),
+                        Amount = 50,
+                        ProductGroupId = productGroup.GetIdentifier()
+                    }
+                }
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var localSubscription = await DbContext.Subscriptions.FirstAsync();
+            localSubscription.Name.Should().Be("Subscription renamed");
+            localSubscription.MonthlyPaymentMoment.Should().Be(SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth);
+        }
+
+        [Fact]
+        public async Task CanEditExpirationDateWithBeneficiaries()
+        {
+            var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
+
+            var futureExpiration = DateTime.UtcNow.AddYears(2);
+            subscription.IsFundsAccumulable = true;
+            subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
+            subscription.FundsExpirationDate = futureExpiration;
+            AssignBeneficiaryToSubscription(localBeneficiaryType);
+
+            var newExpiration = new LocalDate(futureExpiration.Year + 1, 1, 1);
+            var input = new Input()
+            {
+                SubscriptionId = subscription.GetIdentifier(),
+                Name = "Subscription 1",
+                StartDate = new LocalDate(2022, 1, 1),
+                EndDate = new LocalDate(2022, 3, 30),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
+                FundsExpirationDate = newExpiration,
+                Types = new List<EditSubscriptionTypeInput>() {
+                    new EditSubscriptionTypeInput
+                    {
+                        BeneficiaryTypeId = localBeneficiaryType.GetIdentifier(),
+                        Amount = 50,
+                        ProductGroupId = productGroup.GetIdentifier()
+                    }
+                }
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var localSubscription = await DbContext.Subscriptions.FirstAsync();
+            localSubscription.FundsExpirationDate.Should().Be(newExpiration.AtMidnight().InUtc().ToDateTimeUtc());
+        }
+
+        [Fact]
+        public async Task ThrowsIfExpirationDateEditedAfterExpiry()
+        {
+            var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
+
+            subscription.IsFundsAccumulable = true;
+            subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
+            subscription.FundsExpirationDate = DateTime.UtcNow.AddYears(-1);
+            AssignBeneficiaryToSubscription(localBeneficiaryType);
+
+            var input = new Input()
+            {
+                SubscriptionId = subscription.GetIdentifier(),
+                Name = "Subscription 1",
+                StartDate = new LocalDate(2022, 1, 1),
+                EndDate = new LocalDate(2022, 3, 30),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
+                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
                 Types = new List<EditSubscriptionTypeInput>() {
                     new EditSubscriptionTypeInput
                     {
@@ -187,7 +260,130 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
             };
 
             await F(() => handler.Handle(input, CancellationToken.None))
-                .Should().ThrowAsync<EditSubscription.CantEditSubscriptionWithBeneficiaries>();
+                .Should().ThrowAsync<EditSubscription.ExpirationDateAlreadyPassedException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfExpirationDateEditedWhenNumberOfDaysTrigger()
+        {
+            var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
+
+            subscription.IsFundsAccumulable = true;
+            subscription.TriggerFundExpiration = FundsExpirationTrigger.NumberOfDays;
+            subscription.FundsExpirationDate = DateTime.UtcNow.AddYears(2);
+            AssignBeneficiaryToSubscription(localBeneficiaryType);
+
+            var input = new Input()
+            {
+                SubscriptionId = subscription.GetIdentifier(),
+                Name = "Subscription 1",
+                StartDate = new LocalDate(2022, 1, 1),
+                EndDate = new LocalDate(2022, 3, 30),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
+                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
+                Types = new List<EditSubscriptionTypeInput>() {
+                    new EditSubscriptionTypeInput
+                    {
+                        BeneficiaryTypeId = localBeneficiaryType.GetIdentifier(),
+                        Amount = 50,
+                        ProductGroupId = productGroup.GetIdentifier()
+                    }
+                }
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<EditSubscription.CantEditExpirationDateException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfExpirationDateEditedWhenNotAccumulable()
+        {
+            var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
+
+            subscription.IsFundsAccumulable = false;
+            subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
+            subscription.FundsExpirationDate = DateTime.UtcNow.AddYears(2);
+            AssignBeneficiaryToSubscription(localBeneficiaryType);
+
+            var input = new Input()
+            {
+                SubscriptionId = subscription.GetIdentifier(),
+                Name = "Subscription 1",
+                StartDate = new LocalDate(2022, 1, 1),
+                EndDate = new LocalDate(2022, 3, 30),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
+                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
+                Types = new List<EditSubscriptionTypeInput>() {
+                    new EditSubscriptionTypeInput
+                    {
+                        BeneficiaryTypeId = localBeneficiaryType.GetIdentifier(),
+                        Amount = 50,
+                        ProductGroupId = productGroup.GetIdentifier()
+                    }
+                }
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<EditSubscription.CantEditExpirationDateException>();
+        }
+
+        [Fact]
+        public async Task CanEditExpirationDateAlsoUpdatesExistingTransactions()
+        {
+            var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
+
+            var futureExpiration = DateTime.UtcNow.AddYears(2);
+            subscription.IsFundsAccumulable = true;
+            subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
+            subscription.FundsExpirationDate = futureExpiration;
+            var beneficiary = AssignBeneficiaryToSubscription(localBeneficiaryType);
+
+            var card = new Card()
+            {
+                Funds = new List<Fund>(),
+                Status = CardStatus.Assigned,
+                Project = project,
+                Beneficiary = beneficiary,
+                Transactions = new List<Transaction>()
+                {
+                    new SubscriptionAddingFundTransaction()
+                    {
+                        Amount = 25,
+                        AvailableFund = 25,
+                        Status = FundTransactionStatus.Actived,
+                        ExpirationDate = futureExpiration,
+                        ProductGroup = productGroup,
+                        Beneficiary = beneficiary,
+                        SubscriptionType = subscriptionType
+                    }
+                }
+            };
+            DbContext.Cards.Add(card);
+            DbContext.SaveChanges();
+
+            var newExpiration = new LocalDate(futureExpiration.Year + 1, 1, 1);
+            var input = new Input()
+            {
+                SubscriptionId = subscription.GetIdentifier(),
+                Name = "Subscription 1",
+                StartDate = new LocalDate(2022, 1, 1),
+                EndDate = new LocalDate(2022, 3, 30),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
+                FundsExpirationDate = newExpiration,
+                Types = new List<EditSubscriptionTypeInput>() {
+                    new EditSubscriptionTypeInput
+                    {
+                        BeneficiaryTypeId = localBeneficiaryType.GetIdentifier(),
+                        Amount = 50,
+                        ProductGroupId = productGroup.GetIdentifier()
+                    }
+                }
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var updatedTransaction = await DbContext.Transactions.OfType<SubscriptionAddingFundTransaction>().FirstAsync();
+            updatedTransaction.ExpirationDate.Should().Be(newExpiration.AtMidnight().InUtc().ToDateTimeUtc());
         }
 
         [Fact]
@@ -200,7 +396,6 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 Name = "Subscription 1 test",
                 StartDate = new LocalDate(2022, 2, 1),
                 EndDate = new LocalDate(2022, 4, 30),
-                FundsExpirationDate = new LocalDate(2022, 5, 1),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth,
                 Types = new List<EditSubscriptionTypeInput>() {
                     new EditSubscriptionTypeInput
@@ -228,7 +423,6 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 Name = "Subscription 1 test",
                 StartDate = new LocalDate(2022, 2, 1),
                 EndDate = new LocalDate(2022, 4, 30),
-                FundsExpirationDate = new LocalDate(2022, 5, 1),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth,
                 Types = new List<EditSubscriptionTypeInput>() {
                     new EditSubscriptionTypeInput

--- a/Sig.App.Frontend/src/components/ui/switch.vue
+++ b/Sig.App.Frontend/src/components/ui/switch.vue
@@ -5,6 +5,7 @@
     </slot>
     <Switch
       :model-value="modelValue"
+      :disabled="disabled"
       class="relative inline-flex flex-shrink-0 h-4 w-8 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
       :class="bgColorClass"
       @update:model-value="(v) => emit('update:modelValue', v)">
@@ -60,7 +61,11 @@ const props = defineProps({
   },
   showIconOnly: Boolean,
   modelValue: Boolean,
-  changeColor: Boolean
+  changeColor: Boolean,
+  disabled: {
+    type: Boolean,
+    default: false
+  }
 });
 
 const emit = defineEmits(["update:modelValue"]);

--- a/Sig.App.Frontend/src/views/subscription/EditSubscription.vue
+++ b/Sig.App.Frontend/src/views/subscription/EditSubscription.vue
@@ -32,9 +32,11 @@
       :subscription-payment-based-card-usage="subscription.isSubscriptionPaymentBasedCardUsage"
       :trigger-fund-expiration="subscription.triggerFundExpiration"
       :max-number-of-payments="subscription.isSubscriptionPaymentBasedCardUsage ? subscription.maxNumberOfPayments : null"
+      :have-any-beneficiaries="subscription.haveAnyBeneficiaries"
       :number-days-until-funds-expire="
         subscription.triggerFundExpiration === NUMBER_OF_DAYS ? subscription.numberDaysUntilFundsExpire : null
       "
+      :can-edit-funds-expiration-date="canEditFundsExpirationDate"
       :submit-btn="t('edit-subscription')"
       @closeModal="closeModal"
       @submit="onSubmit" />
@@ -49,7 +51,7 @@ import { useRouter, useRoute } from "vue-router";
 import { useQuery, useResult, useMutation } from "@vue/apollo-composable";
 
 import { URL_SUBSCRIPTION_ADMIN } from "@/lib/consts/urls";
-import { NUMBER_OF_DAYS } from "@/lib/consts/funds-expiration-trigger";
+import { NUMBER_OF_DAYS, SPECIFIC_DATE } from "@/lib/consts/funds-expiration-trigger";
 import { subscriptionName } from "@/lib/helpers/subscription";
 
 import { formatDate, serverFormat, formattedDate } from "@/lib/helpers/date";
@@ -88,6 +90,7 @@ const { result, loading } = useQuery(
         fundsExpirationDate
         triggerFundExpiration
         numberDaysUntilFundsExpire
+        haveAnyBeneficiaries
         types {
           id
           productGroup {
@@ -128,6 +131,7 @@ const { mutate: editSubscription } = useMutation(
           fundsExpirationDate
           triggerFundExpiration
           numberDaysUntilFundsExpire
+          haveAnyBeneficiaries
           types {
             id
             productGroup {
@@ -147,6 +151,16 @@ const { mutate: editSubscription } = useMutation(
     }
   `
 );
+
+const canEditFundsExpirationDate = computed(() => {
+  if (!subscription.value?.haveAnyBeneficiaries) return true;
+  return (
+    subscription.value?.isFundsAccumulable &&
+    subscription.value?.triggerFundExpiration === SPECIFIC_DATE &&
+    subscription.value?.fundsExpirationDate &&
+    new Date(subscription.value.fundsExpirationDate) > new Date()
+  );
+});
 
 const productGroupSubscriptionTypes = computed(() => {
   let results = [];

--- a/Sig.App.Frontend/src/views/subscription/_Form.vue
+++ b/Sig.App.Frontend/src/views/subscription/_Form.vue
@@ -12,13 +12,13 @@
     "first-and-fifteenth-day-of-the-month": "The first and 15th day of the month",
 		"monthly-payment-moment": "Automated payment schedule",
 		"subscription-end-date": "End of payment period",
-		"subscription-end-date-error": "The “End date” field must be greater than the “Start date” field",
+		"subscription-end-date-error": "The 'End date' field must be greater than the “Start date” field",
 		"subscription-name": "Name",
     "subscription-name-desc": "<p>These settings will determine the dates on which funds will be automatically added onto cards. (In later steps, you will define expiration dates and the amounts the cards will receive.) Note that subscriptions <b>cannot be modified</b> once they have been assigned to participants!</p>",
 		"subscription-name-placeholder": "Ex. Winter 2022",
 		"subscription-start-date": "Beginning of payment period",
     "subscription-funds-expiration-date": "Fund expiry date",
-    "subscription-funds-expiration-date-error": "The “Fund expiry date” field  must be later than the “End of payment period” field",
+    "subscription-funds-expiration-date-error": "The \”Fund expiry date\” field must be later than the \”End of payment period\” field and after today's date.",
     "subscription-type-amount": "Amount",
     "subscription-type-category": "Participant category",
     "subscription-funds-accumulable": "Cumulative funds",
@@ -65,7 +65,7 @@
 		"subscription-start-date": "Début période de versements",
 		"subscription-type-amount": "Montant",
     "subscription-funds-expiration-date": "Date maximale d’expiration des fonds",
-    "subscription-funds-expiration-date-error": "Le champ «Date maximale d’expiration des fonds» doit être ultérieur à la fin de la période de versements.",
+    "subscription-funds-expiration-date-error": "Le champ «Date maximale d’expiration des fonds» doit être ultérieur à la fin de la période de versements et à la date du jour (aujourd'hui).",
     "subscription-type-category": "Catégorie de participant·e",
     "subscription-funds-accumulable": "Fonds accumulables",
     "previous": "Précédent",
@@ -133,6 +133,7 @@
             id="startDate"
             v-bind="field"
             class="sm:col-span-6"
+            :disabled="haveAnyBeneficiaries"
             :label="t('subscription-start-date')"
             :errors="fieldErrors"
             is-inside-modal
@@ -143,6 +144,7 @@
             id="endDate"
             v-bind="field"
             class="sm:col-span-6"
+            :disabled="haveAnyBeneficiaries"
             :label="t('subscription-end-date')"
             :errors="fieldErrors"
             is-inside-modal
@@ -173,6 +175,7 @@
                 id="isSubscriptionPaymentBasedCardUsage"
                 v-model="subscriptionPaymentBasedCardUsageValue"
                 class="mx-auto mr-0"
+                :disabled="haveAnyBeneficiaries"
                 @update:modelValue="(e) => updateIsSubscriptionPaymentBasedCardUsage(setFieldValue, validateField, e)">
                 <template #left>
                   <span class="mr-2 text-p3 font-semibold">{{
@@ -205,6 +208,7 @@
             :label="t('monthly-payment-moment')"
             :options="monthlyPaymentMomentOptions"
             :errors="fieldErrors"
+            :disabled="haveAnyBeneficiaries"
             @input="(e) => updateMonthlyPaymentMoment(setFieldValue, validateField, e)" />
         </Field>
         <Field v-slot="{ field, errors: fieldErrors }" name="maxNumberOfPayments">
@@ -239,6 +243,7 @@
               <UiSwitch
                 id="isFundsAccumulable"
                 v-model="isFundsAccumulableValue"
+                :disabled="haveAnyBeneficiaries"
                 class="mx-auto mr-0"
                 @update:modelValue="(e) => updateIsFundsAccumulable(setFieldValue, validateField)">
                 <template #left>
@@ -272,6 +277,7 @@
             :label="t('subscription-trigger-fund-expiration')"
             :options="triggerFundExpirationOptions"
             :description="t('subscription-trigger-fund-expiration-desc')"
+            :disabled="haveAnyBeneficiaries"
             @input="(e) => updateTriggerFundExpirationValue(setFieldValue, validateField, e)" />
         </Field>
         <div v-if="triggerFundExpirationValue === NUMBER_OF_DAYS" class="flex sm:col-span-12">
@@ -292,8 +298,8 @@
             class="sm:col-span-6"
             v-bind="inputField"
             :label="t('subscription-funds-expiration-date')"
-            :errors="isFundsAccumulableValue ? fieldErrors : []"
-            :disabled="!isFundsAccumulableValue"
+            :errors="isFundsAccumulableValue && canEditFundsExpirationDate ? fieldErrors : []"
+            :disabled="!isFundsAccumulableValue || !canEditFundsExpirationDate"
             is-inside-modal
             @update:modelValue="forceValidation(values, validateField)" />
         </Field>
@@ -306,7 +312,7 @@
             :errors="fieldErrors"
             input-type="number"
             min="0"
-            :disabled="triggerFundExpirationValue !== NUMBER_OF_DAYS"
+            :disabled="triggerFundExpirationValue !== NUMBER_OF_DAYS || haveAnyBeneficiaries"
             @input="(e) => updateNumberDaysUntilFundsExpireValue(setFieldValue, validateField, e)">
           </PfFormInputText>
         </Field>
@@ -331,6 +337,8 @@
             :delete-label="t('product-group-delete')"
             :empty-list-error="t('empty-product-group-subscription-types-list-error')"
             :errors="formErrors[`productGroupSubscriptionTypes`]"
+            :cant-delete="haveAnyBeneficiaries"
+            :cant-add="haveAnyBeneficiaries"
             @addField="() => createNewProductGroupSubscriptionTypes(push)"
             @removeField="(idx) => remove(idx)">
             <template #default="slotProps">
@@ -343,6 +351,7 @@
                     v-bind="field"
                     :label="t('product-group-select')"
                     :options="productGroups"
+                    :disabled="haveAnyBeneficiaries"
                     :errors="fieldErrors" />
                 </Field>
                 <FieldArray
@@ -356,6 +365,8 @@
                     :add-label="t('add-subscription-type')"
                     :empty-list-error="t('empty-product-group-subscription-types-list-error')"
                     :errors="formErrors[`productGroupSubscriptionTypes[${slotProps.idx}].types`]"
+                    :cant-delete="haveAnyBeneficiaries"
+                    :cant-add="haveAnyBeneficiaries"
                     @addField="() => pushChild({ amount: '', type: '' })"
                     @removeField="(idx) => removeChild(idx)">
                     <template #default="slotPropsType">
@@ -364,6 +375,7 @@
                         :name="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].type`">
                         <PfFormInputSelect
                           :id="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].type`"
+                          :disabled="haveAnyBeneficiaries"
                           class="grow"
                           v-bind="inputField"
                           :label="t('subscription-type-category')"
@@ -376,6 +388,7 @@
                         :name="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].amount`">
                         <PfFormInputText
                           :id="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].amount`"
+                          :disabled="haveAnyBeneficiaries"
                           v-bind="inputField"
                           :label="t('subscription-type-amount')"
                           :errors="fieldErrors"
@@ -480,6 +493,14 @@ const props = defineProps({
   projectId: {
     type: String,
     required: true
+  },
+  haveAnyBeneficiaries: {
+    type: Boolean,
+    default: false
+  },
+  canEditFundsExpirationDate: {
+    type: Boolean,
+    default: true
   }
 });
 
@@ -606,7 +627,7 @@ const validationSchemas = computed(() => {
               params: {},
               message: t("subscription-funds-expiration-date-error"),
               test: function (value, form) {
-                return new Date(value) > new Date(form.parent.endDate);
+                return new Date(value) > new Date(form.parent.endDate) && new Date(value) > new Date();
               }
             })
             .required();

--- a/Sig.App.Frontend/src/views/subscription/_Form.vue
+++ b/Sig.App.Frontend/src/views/subscription/_Form.vue
@@ -12,13 +12,13 @@
     "first-and-fifteenth-day-of-the-month": "The first and 15th day of the month",
 		"monthly-payment-moment": "Automated payment schedule",
 		"subscription-end-date": "End of payment period",
-		"subscription-end-date-error": "The 'End date' field must be greater than the “Start date” field",
+		"subscription-end-date-error": "The 'End date' field must be greater than the \"Start date\" field",
 		"subscription-name": "Name",
     "subscription-name-desc": "<p>These settings will determine the dates on which funds will be automatically added onto cards. (In later steps, you will define expiration dates and the amounts the cards will receive.) Note that subscriptions <b>cannot be modified</b> once they have been assigned to participants!</p>",
 		"subscription-name-placeholder": "Ex. Winter 2022",
 		"subscription-start-date": "Beginning of payment period",
     "subscription-funds-expiration-date": "Fund expiry date",
-    "subscription-funds-expiration-date-error": "The \”Fund expiry date\” field must be later than the \”End of payment period\” field and after today's date.",
+    "subscription-funds-expiration-date-error": "The \"Fund expiry date\" field must be later than the \"End of payment period\" field and after today's date.",
     "subscription-type-amount": "Amount",
     "subscription-type-category": "Participant category",
     "subscription-funds-accumulable": "Cumulative funds",
@@ -64,13 +64,13 @@
 		"subscription-name-placeholder": "Ex. Hiver 2022",
 		"subscription-start-date": "Début période de versements",
 		"subscription-type-amount": "Montant",
-    "subscription-funds-expiration-date": "Date maximale d’expiration des fonds",
-    "subscription-funds-expiration-date-error": "Le champ «Date maximale d’expiration des fonds» doit être ultérieur à la fin de la période de versements et à la date du jour (aujourd'hui).",
+    "subscription-funds-expiration-date": "Date maximale d'expiration des fonds",
+    "subscription-funds-expiration-date-error": "Le champ «Date maximale d'expiration des fonds» doit être ultérieur à la fin de la période de versements et à la date du jour (aujourd'hui).",
     "subscription-type-category": "Catégorie de participant·e",
     "subscription-funds-accumulable": "Fonds accumulables",
     "previous": "Précédent",
     "set-period": "Définir la période des versements",
-    "set-expiration": "Définir les dates d’expiration",
+    "set-expiration": "Définir les dates d'expiration",
     "set-amounts": "Définir les montants",
     "subscription-funds-accumulable-disabled": "Désactivé",
     "subscription-funds-accumulable-enabled": "Activé",
@@ -84,7 +84,7 @@
     "subscription-payment-based-card-usage-enabled": "Activé",
     "subscription-payment-based-card-usage-disabled": "Désactivé",
     "subscription-max-number-of-payments": "Nombre total maximum de versements",
-    "subscription-trigger-fund-expiration": "Déclencheur de l’expiration des fonds",
+    "subscription-trigger-fund-expiration": "Déclencheur de l'expiration des fonds",
     "subscription-trigger-fund-expiration-desc": "Les fonds de cet abonnement expireront au début de la date sélectionnée (00h01 heure de l'Est)",
     "subscription-trigger-fund-expiration-specific-date": "Une date spécifique",
     "subscription-trigger-fund-expiration-number-of-days": "Un nombre de jours après la première utilisation",
@@ -96,73 +96,37 @@
 </i18n>
 
 <template>
-  <Form
-    v-slot="{ isSubmitting, errors: formErrors, values, validateField, setFieldValue }"
-    :initial-values="initialValues"
-    :validation-schema="currentSchema"
-    keep-values
-    @submit="nextStep">
-    <UiStepper
-      class="mb-6"
+  <Form v-slot="{ isSubmitting, errors: formErrors, values, validateField, setFieldValue }"
+    :initial-values="initialValues" :validation-schema="currentSchema" keep-values @submit="nextStep">
+    <UiStepper class="mb-6"
       :step-label="currentStep === 0 ? t('set-period') : currentStep === 1 ? t('set-expiration') : t('set-amounts')"
-      :step-count="3"
-      :step-number="currentStep + 1" />
-    <PfForm
-      v-if="currentStep === 0"
-      has-footer
-      can-cancel
-      :disable-submit="Object.keys(formErrors).length > 0"
-      :submit-label="t('set-expiration')"
-      :cancel-label="t('cancel')"
-      :processing="isSubmitting"
-      @cancel="closeModal">
+      :step-count="3" :step-number="currentStep + 1" />
+    <PfForm v-if="currentStep === 0" has-footer can-cancel :disable-submit="Object.keys(formErrors).length > 0"
+      :submit-label="t('set-expiration')" :cancel-label="t('cancel')" :processing="isSubmitting" @cancel="closeModal">
       <PfFormSection is-grid>
         <Field v-slot="{ field, errors: fieldErrors }" name="subscriptionName">
-          <PfFormInputText
-            id="subscriptionName"
-            col-span-class="sm:col-span-12"
-            v-bind="field"
-            :label="t('subscription-name')"
-            :placeholder="t('subscription-name-placeholder')"
-            :errors="fieldErrors" />
+          <PfFormInputText id="subscriptionName" col-span-class="sm:col-span-12" v-bind="field"
+            :label="t('subscription-name')" :placeholder="t('subscription-name-placeholder')" :errors="fieldErrors" />
         </Field>
         <!-- eslint-disable vue/no-v-html @intlify/vue-i18n/no-v-html -->
         <div class="flex sm:col-span-12" v-html="t('subscription-name-desc')"></div>
         <Field v-slot="{ field, errors: fieldErrors }" name="startDate">
-          <DatePicker
-            id="startDate"
-            v-bind="field"
-            class="sm:col-span-6"
-            :disabled="haveAnyBeneficiaries"
-            :label="t('subscription-start-date')"
-            :errors="fieldErrors"
-            is-inside-modal
+          <DatePicker id="startDate" v-bind="field" class="sm:col-span-6" :disabled="haveAnyBeneficiaries"
+            :label="t('subscription-start-date')" :errors="fieldErrors" is-inside-modal
             @update:modelValue="forceValidation(values, validateField)" />
         </Field>
         <Field v-slot="{ field, errors: fieldErrors }" name="endDate">
-          <DatePicker
-            id="endDate"
-            v-bind="field"
-            class="sm:col-span-6"
-            :disabled="haveAnyBeneficiaries"
-            :label="t('subscription-end-date')"
-            :errors="fieldErrors"
-            is-inside-modal
+          <DatePicker id="endDate" v-bind="field" class="sm:col-span-6" :disabled="haveAnyBeneficiaries"
+            :label="t('subscription-end-date')" :errors="fieldErrors" is-inside-modal
             @update:modelValue="forceValidation(values, validateField)" />
         </Field>
         <div class="flex flex-col sm:col-span-12">
-          <span
-            v-if="getSubscriptionPaymentDates.length > 0"
-            class="text-sm text-grey-500 dark:text-grey-400"
-            v-html="
-              t('subscription-payment-dates-desc', {
-                count: getSubscriptionPaymentDates.length,
-                dates: getSubscriptionPaymentDates.join(', ')
-              })
+          <span v-if="getSubscriptionPaymentDates.length > 0" class="text-sm text-grey-500 dark:text-grey-400" v-html="t('subscription-payment-dates-desc', {
+            count: getSubscriptionPaymentDates.length,
+            dates: getSubscriptionPaymentDates.join(', ')
+          })
             "></span>
-          <span
-            v-else
-            class="text-sm text-grey-500 dark:text-grey-400"
+          <span v-else class="text-sm text-grey-500 dark:text-grey-400"
             v-html="t('subscription-payment-dates-desc', { count: '-', dates: '-' })"></span>
         </div>
         <Field name="isSubscriptionPaymentBasedCardUsage">
@@ -171,11 +135,8 @@
               <span class="text-sm font-medium text-grey-900 dark:text-grey-200">{{
                 t("subscription-payment-based-card-usage")
               }}</span>
-              <UiSwitch
-                id="isSubscriptionPaymentBasedCardUsage"
-                v-model="subscriptionPaymentBasedCardUsageValue"
-                class="mx-auto mr-0"
-                :disabled="haveAnyBeneficiaries"
+              <UiSwitch id="isSubscriptionPaymentBasedCardUsage" v-model="subscriptionPaymentBasedCardUsageValue"
+                class="mx-auto mr-0" :disabled="haveAnyBeneficiaries"
                 @update:modelValue="(e) => updateIsSubscriptionPaymentBasedCardUsage(setFieldValue, validateField, e)">
                 <template #left>
                   <span class="mr-2 text-p3 font-semibold">{{
@@ -188,64 +149,39 @@
             </div>
             <div class="flex sm:col-span-12">
               <!-- eslint-disable vue/no-v-html @intlify/vue-i18n/no-v-html -->
-              <span
-                v-if="!subscriptionPaymentBasedCardUsageValue"
-                class="text-sm text-grey-500 dark:text-grey-400"
+              <span v-if="!subscriptionPaymentBasedCardUsageValue" class="text-sm text-grey-500 dark:text-grey-400"
                 v-html="t('subscription-payment-based-card-usage-desc-deactivated')"></span>
-              <span
-                v-else
-                class="text-sm text-grey-500 dark:text-grey-400"
+              <span v-else class="text-sm text-grey-500 dark:text-grey-400"
                 v-html="t('subscription-payment-based-card-usage-desc-activated')"></span>
               <!-- eslint-enable vue/no-v-html @intlify/vue-i18n/no-v-html -->
             </div>
           </div>
         </Field>
         <Field v-slot="{ errors: fieldErrors }" name="monthlyPaymentMoment">
-          <PfFormInputSelect
-            id="monthlyPaymentMoment"
-            class="sm:col-span-6"
-            :value="monthlyPaymentMomentValue"
-            :label="t('monthly-payment-moment')"
-            :options="monthlyPaymentMomentOptions"
-            :errors="fieldErrors"
+          <PfFormInputSelect id="monthlyPaymentMoment" class="sm:col-span-6" :value="monthlyPaymentMomentValue"
+            :label="t('monthly-payment-moment')" :options="monthlyPaymentMomentOptions" :errors="fieldErrors"
             :disabled="haveAnyBeneficiaries"
             @input="(e) => updateMonthlyPaymentMoment(setFieldValue, validateField, e)" />
         </Field>
         <Field v-slot="{ field, errors: fieldErrors }" name="maxNumberOfPayments">
-          <PfFormInputText
-            id="maxNumberOfPayments"
-            class="sm:col-span-6"
-            v-bind="field"
-            :label="t('subscription-max-number-of-payments')"
-            :errors="fieldErrors"
-            input-type="number"
-            min="0"
+          <PfFormInputText id="maxNumberOfPayments" class="sm:col-span-6" v-bind="field"
+            :label="t('subscription-max-number-of-payments')" :errors="fieldErrors" input-type="number" min="0"
             :disabled="!subscriptionPaymentBasedCardUsageValue">
           </PfFormInputText>
         </Field>
       </PfFormSection>
     </PfForm>
 
-    <PfForm
-      v-if="currentStep === 1"
-      has-footer
-      can-cancel
-      :disable-submit="Object.keys(formErrors).length > 0"
-      :submit-label="t('set-amounts')"
-      :cancel-label="t('previous')"
-      :processing="isSubmitting"
-      @cancel="prevStep">
+    <PfForm v-if="currentStep === 1" has-footer can-cancel :disable-submit="Object.keys(formErrors).length > 0"
+      :submit-label="t('set-amounts')" :cancel-label="t('previous')" :processing="isSubmitting" @cancel="prevStep">
       <PfFormSection is-grid>
         <Field name="isFundsAccumulable">
           <div class="flex flex-col sm:col-span-12 mb-0">
             <div class="flex flex-row">
-              <span class="text-sm font-medium text-grey-900 dark:text-grey-200">{{ t("subscription-funds-accumulable") }}</span>
-              <UiSwitch
-                id="isFundsAccumulable"
-                v-model="isFundsAccumulableValue"
-                :disabled="haveAnyBeneficiaries"
-                class="mx-auto mr-0"
-                @update:modelValue="(e) => updateIsFundsAccumulable(setFieldValue, validateField)">
+              <span class="text-sm font-medium text-grey-900 dark:text-grey-200">{{ t("subscription-funds-accumulable")
+                }}</span>
+              <UiSwitch id="isFundsAccumulable" v-model="isFundsAccumulableValue" :disabled="haveAnyBeneficiaries"
+                class="mx-auto mr-0" @update:modelValue="(e) => updateIsFundsAccumulable(setFieldValue, validateField)">
                 <template #left>
                   <span class="mr-2 text-p3 font-semibold">{{
                     isFundsAccumulableValue
@@ -257,144 +193,88 @@
             </div>
             <div class="flex sm:col-span-12">
               <!-- eslint-disable vue/no-v-html @intlify/vue-i18n/no-v-html -->
-              <span
-                v-if="!isFundsAccumulableValue"
-                class="text-sm text-grey-500 dark:text-grey-400"
+              <span v-if="!isFundsAccumulableValue" class="text-sm text-grey-500 dark:text-grey-400"
                 v-html="t('subscription-funds-accumulable-desc-deactivated')"></span>
-              <span
-                v-else
-                class="text-sm text-grey-500 dark:text-grey-400"
+              <span v-else class="text-sm text-grey-500 dark:text-grey-400"
                 v-html="t('subscription-funds-accumulable-desc-activated')"></span>
               <!-- eslint-enable vue/no-v-html @intlify/vue-i18n/no-v-html -->
             </div>
           </div>
         </Field>
         <Field name="triggerFundExpiration">
-          <PfFormInputSelect
-            id="triggerFundExpiration"
-            class="sm:col-span-12"
-            :value="triggerFundExpirationValue"
-            :label="t('subscription-trigger-fund-expiration')"
-            :options="triggerFundExpirationOptions"
-            :description="t('subscription-trigger-fund-expiration-desc')"
-            :disabled="haveAnyBeneficiaries"
+          <PfFormInputSelect id="triggerFundExpiration" class="sm:col-span-12" :value="triggerFundExpirationValue"
+            :label="t('subscription-trigger-fund-expiration')" :options="triggerFundExpirationOptions"
+            :description="t('subscription-trigger-fund-expiration-desc')" :disabled="haveAnyBeneficiaries"
             @input="(e) => updateTriggerFundExpirationValue(setFieldValue, validateField, e)" />
         </Field>
         <div v-if="triggerFundExpirationValue === NUMBER_OF_DAYS" class="flex sm:col-span-12">
           <!-- eslint-disable vue/no-v-html @intlify/vue-i18n/no-v-html -->
-          <span
-            class="text-sm text-grey-500 dark:text-grey-400"
-            v-html="
-              t('subscription-trigger-fund-expiration-number-of-days-desc', {
-                numberOfDays:
-                  numberDaysUntilFundsExpire !== '' && numberDaysUntilFundsExpire !== null ? numberDaysUntilFundsExpire : '-'
-              })
+          <span class="text-sm text-grey-500 dark:text-grey-400" v-html="t('subscription-trigger-fund-expiration-number-of-days-desc', {
+            numberOfDays:
+              numberDaysUntilFundsExpire !== '' && numberDaysUntilFundsExpire !== null ? numberDaysUntilFundsExpire : '-'
+          })
             "></span>
           <!-- eslint-enable vue/no-v-html @intlify/vue-i18n/no-v-html -->
         </div>
-        <Field v-slot="{ field: inputField, errors: fieldErrors }" v-model="fundsExpirationDateValue" name="fundsExpirationDate">
-          <DatePicker
-            id="fundsExpirationDate"
-            class="sm:col-span-6"
-            v-bind="inputField"
+        <Field v-slot="{ field: inputField, errors: fieldErrors }" v-model="fundsExpirationDateValue"
+          name="fundsExpirationDate">
+          <DatePicker id="fundsExpirationDate" class="sm:col-span-6" v-bind="inputField"
             :label="t('subscription-funds-expiration-date')"
             :errors="isFundsAccumulableValue && canEditFundsExpirationDate ? fieldErrors : []"
-            :disabled="!isFundsAccumulableValue || !canEditFundsExpirationDate"
-            is-inside-modal
+            :disabled="!isFundsAccumulableValue || !canEditFundsExpirationDate" is-inside-modal
             @update:modelValue="forceValidation(values, validateField)" />
         </Field>
         <Field v-slot="{ errors: fieldErrors }" name="numberDaysUntilFundsExpire">
-          <PfFormInputText
-            id="numberDaysUntilFundsExpire"
-            class="sm:col-span-6"
-            :value="numberDaysUntilFundsExpire"
-            :label="t('subscription-days-until-funds-expire-after-first-use')"
-            :errors="fieldErrors"
-            input-type="number"
-            min="0"
-            :disabled="triggerFundExpirationValue !== NUMBER_OF_DAYS || haveAnyBeneficiaries"
+          <PfFormInputText id="numberDaysUntilFundsExpire" class="sm:col-span-6" :value="numberDaysUntilFundsExpire"
+            :label="t('subscription-days-until-funds-expire-after-first-use')" :errors="fieldErrors" input-type="number"
+            min="0" :disabled="triggerFundExpirationValue !== NUMBER_OF_DAYS || haveAnyBeneficiaries"
             @input="(e) => updateNumberDaysUntilFundsExpireValue(setFieldValue, validateField, e)">
           </PfFormInputText>
         </Field>
       </PfFormSection>
     </PfForm>
 
-    <PfForm
-      v-if="currentStep === 2"
-      has-footer
-      can-cancel
-      :disable-submit="Object.keys(formErrors).length > 0"
-      :submit-label="props.submitBtn"
-      :cancel-label="t('previous')"
-      :processing="isSubmitting"
-      @cancel="prevStep">
+    <PfForm v-if="currentStep === 2" has-footer can-cancel :disable-submit="Object.keys(formErrors).length > 0"
+      :submit-label="props.submitBtn" :cancel-label="t('previous')" :processing="isSubmitting" @cancel="prevStep">
       <PfFormSection>
         <FieldArray v-slot="{ fields, remove, push }" key-path="id" name="productGroupSubscriptionTypes">
-          <UiFieldArray
-            :block-layout="true"
-            :fields="fields"
-            :add-label="t('add-product-group-subscription-type')"
+          <UiFieldArray :block-layout="true" :fields="fields" :add-label="t('add-product-group-subscription-type')"
             :delete-label="t('product-group-delete')"
             :empty-list-error="t('empty-product-group-subscription-types-list-error')"
-            :errors="formErrors[`productGroupSubscriptionTypes`]"
-            :cant-delete="haveAnyBeneficiaries"
-            :cant-add="haveAnyBeneficiaries"
-            @addField="() => createNewProductGroupSubscriptionTypes(push)"
+            :errors="formErrors[`productGroupSubscriptionTypes`]" :cant-delete="haveAnyBeneficiaries"
+            :cant-add="haveAnyBeneficiaries" @addField="() => createNewProductGroupSubscriptionTypes(push)"
             @removeField="(idx) => remove(idx)">
             <template #default="slotProps">
               <div class="sm:col-span-12 space-y-6 divide-y divide-grey-100">
-                <Field
-                  v-slot="{ field, errors: fieldErrors }"
+                <Field v-slot="{ field, errors: fieldErrors }"
                   :name="`productGroupSubscriptionTypes[${slotProps.idx}].productGroupId`">
-                  <PfFormInputSelect
-                    :key="`productGroupSubscriptionTypes[${slotProps.idx}].productGroupId`"
-                    v-bind="field"
-                    :label="t('product-group-select')"
-                    :options="productGroups"
-                    :disabled="haveAnyBeneficiaries"
-                    :errors="fieldErrors" />
+                  <PfFormInputSelect :key="`productGroupSubscriptionTypes[${slotProps.idx}].productGroupId`"
+                    v-bind="field" :label="t('product-group-select')" :options="productGroups"
+                    :disabled="haveAnyBeneficiaries" :errors="fieldErrors" />
                 </Field>
-                <FieldArray
-                  v-slot="{ fields: fieldsChild, remove: removeChild, push: pushChild }"
-                  key-path="id"
+                <FieldArray v-slot="{ fields: fieldsChild, remove: removeChild, push: pushChild }" key-path="id"
                   :name="`productGroupSubscriptionTypes[${slotProps.idx}].types`">
-                  <UiFieldArray
-                    class="pt-3"
-                    :is-inside-block-layout="true"
-                    :fields="fieldsChild"
+                  <UiFieldArray class="pt-3" :is-inside-block-layout="true" :fields="fieldsChild"
                     :add-label="t('add-subscription-type')"
                     :empty-list-error="t('empty-product-group-subscription-types-list-error')"
                     :errors="formErrors[`productGroupSubscriptionTypes[${slotProps.idx}].types`]"
-                    :cant-delete="haveAnyBeneficiaries"
-                    :cant-add="haveAnyBeneficiaries"
-                    @addField="() => pushChild({ amount: '', type: '' })"
-                    @removeField="(idx) => removeChild(idx)">
+                    :cant-delete="haveAnyBeneficiaries" :cant-add="haveAnyBeneficiaries"
+                    @addField="() => pushChild({ amount: '', type: '' })" @removeField="(idx) => removeChild(idx)">
                     <template #default="slotPropsType">
-                      <Field
-                        v-slot="{ field: inputField, errors: fieldErrors }"
+                      <Field v-slot="{ field: inputField, errors: fieldErrors }"
                         :name="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].type`">
                         <PfFormInputSelect
                           :id="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].type`"
-                          :disabled="haveAnyBeneficiaries"
-                          class="grow"
-                          v-bind="inputField"
-                          :label="t('subscription-type-category')"
-                          :options="beneficiaryTypes"
-                          :errors="fieldErrors"
+                          :disabled="haveAnyBeneficiaries" class="grow" v-bind="inputField"
+                          :label="t('subscription-type-category')" :options="beneficiaryTypes" :errors="fieldErrors"
                           col-span-class="sm:col-span-6" />
                       </Field>
-                      <Field
-                        v-slot="{ field: inputField, errors: fieldErrors }"
+                      <Field v-slot="{ field: inputField, errors: fieldErrors }"
                         :name="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].amount`">
                         <PfFormInputText
                           :id="`productGroupSubscriptionTypes[${slotProps.idx}].types[${slotPropsType.idx}].amount`"
-                          :disabled="haveAnyBeneficiaries"
-                          v-bind="inputField"
-                          :label="t('subscription-type-amount')"
-                          :errors="fieldErrors"
-                          input-type="number"
-                          min="0"
-                          col-span-class="sm:col-span-6">
+                          :disabled="haveAnyBeneficiaries" v-bind="inputField" :label="t('subscription-type-amount')"
+                          :errors="fieldErrors" input-type="number" min="0" col-span-class="sm:col-span-6">
                           <template #trailingIcon>
                             <UiDollarSign :errors="fieldErrors" />
                           </template>
@@ -692,15 +572,15 @@ const getSubscriptionPaymentDates = computed(() => {
   if (startDateValue.value && endDateValue.value) {
     const startMonth =
       (monthlyPaymentMomentValue.value === FIRST_DAY_OF_THE_MONTH && startDateValue.value.getDate() === 1) ||
-      (monthlyPaymentMomentValue.value === FIRST_AND_FIFTEENTH_DAY_OF_THE_MONTH && startDateValue.value.getDate() <= 15) ||
-      (monthlyPaymentMomentValue.value === FIFTEENTH_DAY_OF_THE_MONTH && startDateValue.value.getDate() <= 15)
+        (monthlyPaymentMomentValue.value === FIRST_AND_FIFTEENTH_DAY_OF_THE_MONTH && startDateValue.value.getDate() <= 15) ||
+        (monthlyPaymentMomentValue.value === FIFTEENTH_DAY_OF_THE_MONTH && startDateValue.value.getDate() <= 15)
         ? startDateValue.value.getMonth()
         : startDateValue.value.getMonth() + 1;
     let currentDate = new Date(
       startDateValue.value.getFullYear(),
       startMonth,
       monthlyPaymentMomentValue.value === FIFTEENTH_DAY_OF_THE_MONTH ||
-      (monthlyPaymentMomentValue.value === FIRST_AND_FIFTEENTH_DAY_OF_THE_MONTH && startDateValue.value.getDate() <= 15)
+        (monthlyPaymentMomentValue.value === FIRST_AND_FIFTEENTH_DAY_OF_THE_MONTH && startDateValue.value.getDate() <= 15)
         ? 15
         : 1
     );


### PR DESCRIPTION
## [JIRA - [Programme] Permettre la modification d'un abonnement si les changements n'ont pas d'impact sur les enveloppes](https://sigmund-ca.atlassian.net/browse/CRCL-1574)

### Description
Utilisation de Claude Code pour faire la PR.

### Contexte
Une fois qu'un abonnement était attribué à des participant·e·s, il était impossible de le modifier de quelque façon que ce soit : toute tentative d'édition retournait une erreur. En pratique, les gestionnaires de programme avaient besoin de pouvoir corriger le nom d'un abonnement ou repousser la date d'expiration des fonds sans avoir à supprimer et recréer l'abonnement en entier.

### Modifications
**Mutation EditSubscription (API)**
- Suppression du bloc qui bloquait systématiquement toute modification dès qu'un bénéficiaire était assigné.
- La mise à jour est maintenant divisée en deux branches selon la présence de bénéficiaires : modifications complètes si aucun bénéficiaire, modifications restreintes sinon.
- Le nom est toujours modifiable, quel que soit l'état de l'abonnement.
- La date d'expiration des fonds est modifiable uniquement si l'abonnement est accumulable, que le déclencheur est de type date spécifique, et que la date d'expiration courante n'est pas encore passée.
- Lors de la modification de la date d'expiration, toutes les `SubscriptionAddingFundTransaction` actives liées à l'abonnement sont mises à jour avec la nouvelle date.

**Tests (API)**
- Ajout de 6 nouveaux tests : édition du nom avec bénéficiaires, édition de la date d'expiration avec bénéficiaires, erreur si expiration déjà passée, erreur si déclencheur de type nombre de jours, erreur si fonds non accumulables, et vérification que les transactions existantes sont mises à jour.
- Extraction d'un helper `AssignBeneficiaryToSubscription` pour réduire la duplication entre les tests.

**Formulaire d'édition (Frontend)**
- Les champs dates, fréquence de versement, paramètres de paiement, catégories et montants sont désactivés lorsque des bénéficiaires sont assignés.
- La date d'expiration des fonds est désactivée si `canEditFundsExpirationDate` est faux.
- Ajout des props `haveAnyBeneficiaries` et `canEditFundsExpirationDate` au composant `_Form.vue`.
- La propriété `disabled` a été ajoutée au composant UiSwitch.

**Comportement**
Un gestionnaire peut désormais renommer un abonnement même après son attribution à des participant·e·s. Si l'abonnement utilise des fonds accumulables avec une date d'expiration spécifique non encore passée, il peut également repousser cette date, les soldes des cartes existantes sont automatiquement mis à jour. Tous les autres paramètres restent verrouillés tant que des bénéficiaires sont assignés.