### PR TITLE
Fix issue with anonymus data display on DisableCard / UnassignCard + when ListBeneficiaries display all group

### DIFF
--- a/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
@@ -66,13 +66,8 @@
           <div class="flex items-center gap-x-4">
             <span class="text-sm text-primary-700" aria-hidden>{{ t("selected-organization") }}</span>
             <div class="flex flex-col gap-y-2">
-              <PfFormInputSelect
-                id="selectedOrganization"
-                has-hidden-label
-                :label="t('selected-organization')"
-                :value="selectedOrganization"
-                :options="organizations"
-                col-span-class="sm:col-span-3"
+              <PfFormInputSelect id="selectedOrganization" has-hidden-label :label="t('selected-organization')"
+                :value="selectedOrganization" :options="organizations" col-span-class="sm:col-span-3"
                 @input="onOrganizationSelected" />
               <p v-if="isAllGroupSelected" class="text-sm text-red-500">{{ t("selected-all-group-description") }}</p>
             </div>
@@ -80,45 +75,18 @@
         </template>
         <template v-if="organizations" #subpagesCta>
           <div class="flex flex-right gap-x-4 gap-y-3 justify-end">
-            <PfButtonLink
-              v-if="!beneficiariesAreAnonymous"
-              :label="t('add-beneficiary')"
-              tag="routerLink"
-              :to="{ name: URL_BENEFICIARY_ADD }"
-              :icon="ICON_PLUS"
-              :is-disabled="isAllGroupSelected"
-              has-icon-left />
-            <PfButtonLink
-              v-if="!beneficiariesAreAnonymous"
-              :label="t('import-beneficiaries-list')"
-              tag="routerLink"
-              :to="importBeneficiariesListRoute"
-              :icon="ICON_UPLOAD"
-              :is-disabled="isAllGroupSelected"
-              has-icon-left />
-            <PfButtonAction
-              btn-style="outline"
-              :label="t('export-beneficiaries-list')"
-              :icon="ICON_DOWNLOAD"
-              has-icon-left
-              @click="onExportReport" />
+            <PfButtonLink v-if="!beneficiariesAreAnonymous" :label="t('add-beneficiary')" tag="routerLink"
+              :to="{ name: URL_BENEFICIARY_ADD }" :icon="ICON_PLUS" :is-disabled="isAllGroupSelected" has-icon-left />
+            <PfButtonLink v-if="!beneficiariesAreAnonymous" :label="t('import-beneficiaries-list')" tag="routerLink"
+              :to="importBeneficiariesListRoute" :icon="ICON_UPLOAD" :is-disabled="isAllGroupSelected" has-icon-left />
+            <PfButtonAction btn-style="outline" :label="t('export-beneficiaries-list')" :icon="ICON_DOWNLOAD"
+              has-icon-left @click="onExportReport" />
             <template v-if="!beneficiariesAreAnonymous">
-              <PfButtonLink
-                v-if="!administrationSubscriptionsOffPlatform"
-                btn-style="outline"
-                :label="t('download-template-file')"
-                href="/files/Template_Upload.xlsx"
-                file-name="Template_Upload.xlsx"
-                is-downloadable
-                :icon="ICON_TABLE"
-                has-icon-left />
-              <PfButtonAction
-                v-else
-                btn-style="outline"
-                :label="t('download-template-file')"
-                :icon="ICON_TABLE"
-                has-icon-left
-                @click="onDownloadTemplateFile" />
+              <PfButtonLink v-if="!administrationSubscriptionsOffPlatform" btn-style="outline"
+                :label="t('download-template-file')" href="/files/Template_Upload.xlsx" file-name="Template_Upload.xlsx"
+                is-downloadable :icon="ICON_TABLE" has-icon-left />
+              <PfButtonAction v-else btn-style="outline" :label="t('download-template-file')" :icon="ICON_TABLE"
+                has-icon-left @click="onDownloadTemplateFile" />
             </template>
           </div>
         </template>
@@ -127,12 +95,8 @@
         <div class="flex flex-col gap-y-4 sm:flex-row sm:gap-x-4 sm:justify-between sm:items-center pb-5">
           <div class="flex flex-wrap gap-x-4">
             <h2 class="my-0">{{ t("participant-count", { count: beneficiariesPagination.totalCount }) }}</h2>
-            <PfButtonLink
-              v-if="beneficiariesPagination.conflictPaymentCount > 0"
-              class="ml-2 text-red-500"
-              btn-style="link"
-              tag="routerLink"
-              :to="{
+            <PfButtonLink v-if="beneficiariesPagination.conflictPaymentCount > 0" class="ml-2 text-red-500"
+              btn-style="link" tag="routerLink" :to="{
                 name: URL_BENEFICIARY_ADMIN,
                 query: { paymentConflict: BENEFICIARY_WITH_PAYMENT_CONFLICT }
               }">
@@ -143,102 +107,64 @@
             </PfButtonLink>
           </div>
           <div class="lg:flex lg:items-center">
-            <BeneficiaryFilters
-              v-if="selectedOrganization !== ''"
-              v-model="searchInput"
-              :selected-beneficiary-types="beneficiaryTypes"
-              :selected-subscriptions="subscriptions"
-              :selected-status="status"
-              :selected-card-status="cardStatus"
-              :selected-payment-conflict-status="conflictPaymentStatus"
-              :selected-card-disabled="cardDisabled"
+            <BeneficiaryFilters v-if="selectedOrganization !== ''" v-model="searchInput"
+              :selected-beneficiary-types="beneficiaryTypes" :selected-subscriptions="subscriptions"
+              :selected-status="status" :selected-card-status="cardStatus"
+              :selected-payment-conflict-status="conflictPaymentStatus" :selected-card-disabled="cardDisabled"
               :search-filter="searchText"
               :administration-subscriptions-off-platform="administrationSubscriptionsOffPlatform"
-              :without-subscription-id="WITHOUT_SUBSCRIPTION"
-              :beneficiary-status-inactive="BENEFICIARY_STATUS_INACTIVE"
-              :beneficiary-status-active="BENEFICIARY_STATUS_ACTIVE"
-              :card-status-with="BENEFICIARY_WITH_CARD"
+              :without-subscription-id="WITHOUT_SUBSCRIPTION" :beneficiary-status-inactive="BENEFICIARY_STATUS_INACTIVE"
+              :beneficiary-status-active="BENEFICIARY_STATUS_ACTIVE" :card-status-with="BENEFICIARY_WITH_CARD"
               :card-status-without="BENEFICIARY_WITHOUT_CARD"
               :payment-conflict-status-with="BENEFICIARY_WITH_PAYMENT_CONFLICT"
               :payment-conflict-status-without="BENEFICIARY_WITHOUT_PAYMENT_CONFLICT"
-              :card-is-disabled="CARD_IS_DISABLED"
-              :card-is-enabled="CARD_IS_ENABLED"
-              :beneficiaries-are-anonymous="beneficiariesAreAnonymous"
-              :sort-order="sortOrder"
-              :available-beneficiary-types="availableBeneficiaryTypes"
-              :available-subscriptions="availableSubscriptions"
+              :card-is-disabled="CARD_IS_DISABLED" :card-is-enabled="CARD_IS_ENABLED"
+              :beneficiaries-are-anonymous="beneficiariesAreAnonymous" :sort-order="sortOrder"
+              :available-beneficiary-types="availableBeneficiaryTypes" :available-subscriptions="availableSubscriptions"
               @beneficiaryTypesUnchecked="onBeneficiaryTypesUnchecked"
-              @beneficiaryTypesChecked="onBeneficiaryTypesChecked"
-              @subscriptionsUnchecked="onSubscriptionsUnchecked"
-              @subscriptionsChecked="onSubscriptionsChecked"
-              @statusChecked="onStatusChecked"
-              @statusUnchecked="onStatusUnchecked"
-              @cardStatusChecked="onCardStatusChecked"
+              @beneficiaryTypesChecked="onBeneficiaryTypesChecked" @subscriptionsUnchecked="onSubscriptionsUnchecked"
+              @subscriptionsChecked="onSubscriptionsChecked" @statusChecked="onStatusChecked"
+              @statusUnchecked="onStatusUnchecked" @cardStatusChecked="onCardStatusChecked"
               @cardStatusUnchecked="onCardStatusUnchecked"
               @paymentConflictStatusChecked="onPaymentConflictStatusChecked"
               @paymentConflictStatusUnchecked="onPaymentConflictStatusUnchecked"
-              @cardIsDisabledChecked="onCardDisabledChecked"
-              @cardIsDisabledUnchecked="onCardDisabledUnchecked"
-              @sortOrderChanged="onSortOrderChanged"
-              @resetFilters="onResetFilters"
-              @search="onSearch" />
+              @cardIsDisabledChecked="onCardDisabledChecked" @cardIsDisabledUnchecked="onCardDisabledUnchecked"
+              @sortOrderChanged="onSortOrderChanged" @resetFilters="onResetFilters" @search="onSearch" />
           </div>
         </div>
 
         <template v-if="selectedOrganization !== '' && beneficiariesPagination.items.length > 0">
-          <ListBeneficiariesWithDetailed
-            :product-groups="productGroups"
+          <ListBeneficiariesWithDetailed :product-groups="productGroups"
             :administration-subscriptions-off-platform="administrationSubscriptionsOffPlatform"
-            :beneficiaries-pagination="beneficiariesPagination"
-            :beneficiaries-are-anonymous="beneficiariesAreAnonymous"
-            :filtered-query="filteredQuery"
-            :is-all-group-selected="isAllGroupSelected"
-            :organization="organization" />
-          <UiPagination
-            v-if="beneficiariesPagination.totalPages > 1"
-            v-model:page="page"
+            :beneficiaries-pagination="beneficiariesPagination" :beneficiaries-are-anonymous="beneficiariesAreAnonymous"
+            :filtered-query="filteredQuery" :is-all-group-selected="isAllGroupSelected" :organization="organization" />
+          <UiPagination v-if="beneficiariesPagination.totalPages > 1" v-model:page="page"
             :total-pages="beneficiariesPagination.totalPages">
           </UiPagination>
         </template>
 
         <UiEmptyPage v-else>
-          <UiCta
-            v-if="searchText"
-            :img-src="require('@/assets/img/swan.jpg')"
-            :description="t('no-results')"
-            :primary-btn-label="t('reset-search')"
-            primary-btn-is-action
-            @onPrimaryBtnClick="onResetSearch">
+          <UiCta v-if="searchText" :img-src="require('@/assets/img/swan.jpg')" :description="t('no-results')"
+            :primary-btn-label="t('reset-search')" primary-btn-is-action @onPrimaryBtnClick="onResetSearch">
           </UiCta>
-          <UiCta
-            v-else-if="beneficiariesAreAnonymous"
-            :img-src="require('@/assets/img/participants.jpg')"
+          <UiCta v-else-if="beneficiariesAreAnonymous" :img-src="require('@/assets/img/participants.jpg')"
             :description="t('empty-list')" />
-          <UiCta
-            v-else
-            :img-src="require('@/assets/img/participants.jpg')"
-            :description="t('empty-list')"
-            :primary-btn-icon="ICON_UPLOAD"
-            :primary-btn-label="t('import-new-list')"
+          <UiCta v-else :img-src="require('@/assets/img/participants.jpg')" :description="t('empty-list')"
+            :primary-btn-icon="ICON_UPLOAD" :primary-btn-label="t('import-new-list')"
             :primary-btn-route="importBeneficiariesListRoute">
             <template #secondaryBtn>
-              <PfButtonLink
-                v-if="!administrationSubscriptionsOffPlatform"
-                btn-style="link"
-                :label="t('download-template-file')"
-                href="/files/Template_Upload.xlsx"
+              <PfButtonLink v-if="!administrationSubscriptionsOffPlatform" btn-style="link"
+                :label="t('download-template-file')" href="/files/Template_Upload.xlsx"
                 file-name="Template_Upload.xlsx" />
-              <PfButtonAction v-else btn-style="link" :label="t('download-template-file')" @click="onDownloadTemplateFile" />
+              <PfButtonAction v-else btn-style="link" :label="t('download-template-file')"
+                @click="onDownloadTemplateFile" />
             </template>
           </UiCta>
         </UiEmptyPage>
       </div>
       <UiEmptyPage v-else-if="!loading && !projectsLoading && !organizationsLoading">
-        <UiCta
-          :img-src="require('@/assets/img/organismes.jpg')"
-          :description="t('empty-organizations-list')"
-          :primary-btn-label="t('add-organization')"
-          :primary-btn-route="addOrganizationRoute">
+        <UiCta :img-src="require('@/assets/img/organismes.jpg')" :description="t('empty-organizations-list')"
+          :primary-btn-label="t('add-organization')" :primary-btn-route="addOrganizationRoute">
         </UiCta>
       </UiEmptyPage>
       <Component :is="Component" />
@@ -823,10 +749,11 @@ const beneficiariesPagination = computed(() => {
 });
 
 let beneficiariesAreAnonymous = computed(() => {
-  return (
-    userType.value === USER_TYPE_PROJECTMANAGER &&
-    organizations.value?.find((x) => x.value === selectedOrganization.value)?.beneficiariesAreAnonymous
-  );
+  if (userType.value !== USER_TYPE_PROJECTMANAGER) return false;
+  const org = isAllGroupSelected.value
+    ? organizations.value?.find((x) => x.value !== ALL_GROUP)
+    : organizations.value?.find((x) => x.value === selectedOrganization.value);
+  return org?.beneficiariesAreAnonymous ?? false;
 });
 
 const budgetAllowancesTotal = computed(() => {

--- a/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ListBeneficiaries.vue
@@ -748,7 +748,7 @@ const beneficiariesPagination = computed(() => {
   return organizationBeneficiariesPagination.value;
 });
 
-let beneficiariesAreAnonymous = computed(() => {
+const beneficiariesAreAnonymous = computed(() => {
   if (userType.value !== USER_TYPE_PROJECTMANAGER) return false;
   const org = isAllGroupSelected.value
     ? organizations.value?.find((x) => x.value !== ALL_GROUP)

--- a/Sig.App.Frontend/src/views/card/DisableCard.vue
+++ b/Sig.App.Frontend/src/views/card/DisableCard.vue
@@ -5,6 +5,8 @@
     "delete-text-card-number-error": "Text must match card number",
 		"delete-text-beneficiary-name-label": "Type the participant's full name to confirm",
     "delete-text-card-number-label": "Type the card number to confirm",
+    "delete-text-beneficiary-anonymous-label": "Type the participant's ID1 to confirm",
+    "delete-text-beneficiary-anonymous-error": "Text must match participant's ID1",
 		"description": "Warning! If you continue, the card will be deactivated and the participant will not be able to use the card until it is reactivated.",
 		"title": "Deactivate Card - {beneficiaryName}",
 		"disable-btn-label": "Deactivate",
@@ -14,6 +16,8 @@
 		"delete-text-beneficiary-name-error": "Le texte doit correspondre au prénom et au nom de famille du ou de la participant·e",
     "delete-text-card-number-error": "Le texte doit correspondre au numéro de la carte",
 		"delete-text-beneficiary-name-label": "Taper le nom complet du ou de la participant·e pour confirmer",
+    "delete-text-beneficiary-anonymous-label": "Taper le ID1 du participant·e pour confirmer",
+    "delete-text-beneficiary-anonymous-error": "Le texte doit correspondre au ID1 du participant·e",
     "delete-text-card-number-label": "Taper le numéro de la carte pour confirmer",
 		"description": "Avertissement ! Si vous continuez, la carte sera désactivée et le·a participant·e ne pourra plus utiliser la carte tant qu'elle n'est pas réactivée.",
 		"title": "Désactiver la carte - {beneficiaryName}",
@@ -24,15 +28,10 @@
 </i18n>
 
 <template>
-  <UiDialogDeleteModal
-    :return-route="returnRoute()"
-    :title="t('title', { beneficiaryName: getBeneficiaryName() })"
-    :description="t('description', { beneficiaryName: getBeneficiaryName() })"
-    :validation-text="getBeneficiaryName()"
-    :delete-text-label="deleteTextLabel"
-    :delete-text-error="deleteTextError"
-    :delete-button-label="t('disable-btn-label')"
-    @onDelete="onDisableCard" />
+  <UiDialogDeleteModal :return-route="returnRoute()" :title="t('title', { beneficiaryName: getBeneficiaryName() })"
+    :description="t('description', { beneficiaryName: getBeneficiaryName() })" :validation-text="getBeneficiaryName()"
+    :delete-text-label="deleteTextLabel" :delete-text-error="deleteTextError"
+    :delete-button-label="t('disable-btn-label')" @onDelete="onDisableCard" />
 </template>
 
 <script setup>
@@ -58,17 +57,21 @@ const { addSuccess } = useNotificationsStore();
 
 const deleteTextLabel = computed(() => {
   return card.value
-    ? card.value.beneficiary
-      ? t("delete-text-beneficiary-name-label")
-      : t("delete-text-card-number-label")
+    ? card.value.beneficiary?.organization?.project?.beneficiariesAreAnonymous
+      ? t("delete-text-beneficiary-anonymous-label")
+      : card.value.beneficiary
+        ? t("delete-text-beneficiary-name-label")
+        : t("delete-text-card-number-label")
     : "";
 });
 
 const deleteTextError = computed(() => {
   return card.value
-    ? card.value.beneficiary
-      ? t("delete-text-beneficiary-name-error")
-      : t("delete-text-card-number-error")
+    ? card.value.beneficiary?.organization?.project?.beneficiariesAreAnonymous
+      ? t("delete-text-beneficiary-anonymous-error")
+      : card.value.beneficiary
+        ? t("delete-text-beneficiary-name-error")
+        : t("delete-text-card-number-error")
     : "";
 });
 
@@ -82,6 +85,14 @@ const { result } = useQuery(
           id
           firstname
           lastname
+          id1
+          organization {
+            id
+            project {
+              id
+              beneficiariesAreAnonymous
+            }
+          }
         }
       }
     }
@@ -106,6 +117,10 @@ const { mutate: disableCard } = useMutation(
 );
 
 function getBeneficiaryName() {
+  if (!card.value) return "";
+  if (card.value.beneficiary?.organization?.project?.beneficiariesAreAnonymous) {
+    return card.value.beneficiary.id1;
+  }
   return card.value
     ? card.value.beneficiary
       ? `${card.value.beneficiary.firstname} ${card.value.beneficiary.lastname}`

--- a/Sig.App.Frontend/src/views/card/UnassignCard.vue
+++ b/Sig.App.Frontend/src/views/card/UnassignCard.vue
@@ -3,6 +3,8 @@
 	"en": {
 		"delete-text-error": "Text must match participant's first and last name.",
 		"delete-text-label": "Type the participant's full name to confirm",
+    "delete-text-anonymous-label": "Type the participant's ID1 to confirm",
+    "delete-text-anonymous-error": "Text must match participant's ID1",
 		"description": "Warning! Unassigning the card currently belonging to <strong>{beneficiaryName}</strong> cannot be undone. If you continue, the card will be unassigned and the card funds will be removed. Payments to the card can no longer be traced.",
 		"title": "Unassign Card - {beneficiaryName}",
 		"unassign-btn-label": "Unassign",
@@ -11,6 +13,8 @@
 	"fr": {
 		"delete-text-error": "Le texte doit correspondre au prénom et au nom de famille du ou de la participant·e",
 		"delete-text-label": "Taper le nom complet du ou de la participant·e pour confirmer",
+    "delete-text-anonymous-label": "Taper le ID1 du participant·e pour confirmer",
+    "delete-text-anonymous-error": "Le texte doit correspondre au ID1 du participant·e",
 		"description": "Avertissement ! La désassignation de la carte de <strong>{beneficiaryName}</strong> ne peut pas être annulée. Si vous continuez, la carte sera désassignée et les fonds de la carte vont être supprimé. Les paiements sur la carte ne pourront plus être retracés.",
 		"title": "Désassigner la carte - {beneficiaryName}",
 		"unassign-btn-label": "Désassigner",
@@ -20,15 +24,10 @@
 </i18n>
 
 <template>
-  <UiDialogDeleteModal
-    :return-route="returnRoute()"
-    :title="t('title', { beneficiaryName: getBeneficiaryName() })"
-    :description="t('description', { beneficiaryName: getBeneficiaryName() })"
-    :validation-text="getBeneficiaryName()"
-    :delete-text-label="t('delete-text-label')"
-    :delete-text-error="t('delete-text-error')"
-    :delete-button-label="t('unassign-btn-label')"
-    @onDelete="unassignCard" />
+  <UiDialogDeleteModal :return-route="returnRoute()" :title="t('title', { beneficiaryName: getBeneficiaryName() })"
+    :description="t('description', { beneficiaryName: getBeneficiaryName() })" :validation-text="getBeneficiaryName()"
+    :delete-text-label="deleteTextLabel" :delete-text-error="deleteTextError"
+    :delete-button-label="t('unassign-btn-label')" @onDelete="unassignCard" />
 </template>
 
 <script setup>
@@ -36,6 +35,7 @@ import gql from "graphql-tag";
 import { useQuery, useResult, useMutation } from "@vue/apollo-composable";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
+import { computed } from "vue";
 
 import { useNotificationsStore } from "@/lib/store/notifications";
 import { URL_CARDS, URL_BENEFICIARY_ADMIN, URL_CARDS_UNASSIGN } from "@/lib/consts/urls";
@@ -45,6 +45,20 @@ const route = useRoute();
 const router = useRouter();
 const { addSuccess } = useNotificationsStore();
 
+const deleteTextLabel = computed(() => {
+  if (!beneficiary.value) return "";
+  return beneficiary.value?.organization?.project?.beneficiariesAreAnonymous
+    ? t("delete-text-anonymous-label")
+    : t("delete-text-label");
+});
+
+const deleteTextError = computed(() => {
+  if (!beneficiary.value) return "";
+  return beneficiary.value?.organization?.project?.beneficiariesAreAnonymous
+    ? t("delete-text-anonymous-error")
+    : t("delete-text-error");
+});
+
 const { result } = useQuery(
   gql`
     query Beneficiary($id: ID!) {
@@ -52,6 +66,14 @@ const { result } = useQuery(
         id
         firstname
         lastname
+        id1
+        organization {
+          id
+          project {
+            id
+            beneficiariesAreAnonymous
+          }
+        }
       }
     }
   `,
@@ -74,7 +96,12 @@ const { mutate: unassignCardFromBeneficiary } = useMutation(
 );
 
 function getBeneficiaryName() {
-  return beneficiary.value ? `${beneficiary.value.firstname} ${beneficiary.value.lastname}` : "";
+  if (!beneficiary.value) return "";
+
+  if (beneficiary.value.organization.project.beneficiariesAreAnonymous) {
+    return beneficiary.value.id1;
+  }
+  return `${beneficiary.value.firstname} ${beneficiary.value.lastname}`;
 }
 
 async function unassignCard() {
@@ -85,9 +112,7 @@ async function unassignCard() {
     }
   });
 
-  addSuccess(
-    t("unassign-card-success-notification", { beneficiaryName: `${beneficiary.value.firstname} ${beneficiary.value.lastname}` })
-  );
+  addSuccess(t("unassign-card-success-notification", { beneficiaryName: getBeneficiaryName() }));
   router.push(returnRoute());
 }
 


### PR DESCRIPTION
### [JIRA - Programme anonyme - Les détails des participant-es sont affichés lorsque "Tous les groupes" est sélectionné #185](https://sigmund-ca.atlassian.net/browse/CRCL-2336)
### [JIRA - Programme anonyme - désactiver une carte - le nom du participant est affiché #183](https://sigmund-ca.atlassian.net/browse/CRCL-2335)

### Description
Utilisation de Claude Code pour faire la PR.

### Contexte
Dans les projets où les bénéficiaires sont anonymes `beneficiariesAreAnonymous`, certaines actions exposaient ou utilisaient incorrectement les données personnelles (prénom, nom) des participant·e·s. Deux problèmes distincts ont été identifiés : les modales de désactivation et de désassignation de carte affichaient le nom complet même pour les participant·e·s anonymes, et la liste des bénéficiaires n'appliquait pas correctement le mode anonyme lorsque le groupe « Tous » était sélectionné.

### Modifications
**DisableCard**
- Les propriétés calculées `deleteTextLabel` et `deleteTextError` vérifient maintenant le statut anonyme avant de choisir quel libellé et quel message d'erreur afficher.
- `getBeneficiaryName()` retourne désormais `id1` au lieu du nom complet si le projet est en mode anonyme.
- Ajout des clés i18n (FR/EN) pour les libellés et erreurs spécifiques aux participant·e·s anonymes.

**UnassignCard**
- Ajout des propriétés calculées `deleteTextLabel` et `deleteTextError` (la modale utilisait auparavant des clés statiques, sans distinction pour l'anonymat).
- `getBeneficiaryName()` retourne `id1` pour les participant·e·s anonymes.
- Correction de la notification de succès qui utilisait systématiquement `firstname` & `lastname` au lieu de passer par `getBeneficiaryName()`.
- Ajout des clés i18n (FR/EN) correspondantes.

**ListBeneficiaries**
- Correction du computed `beneficiariesAreAnonymous` : lorsque le groupe « Tous » est sélectionné, la logique cherchait l'organisation correspondant à `selectedOrganization` (qui vaut la constante `ALL_GROUP`), ne trouvait rien et retournait toujours false.
- Le correctif consiste à chercher la première organisation qui n'est pas `ALL_GROUP` pour déterminer le statut anonyme, ce qui reflète fidèlement la configuration du projet.

### Comportement
Pour les projets configurés en mode anonyme, les modales de désactivation et de désassignation de carte affichent maintenant le ID1 du ou de la participant·e (au lieu de son nom complet) dans le titre, la description, le champ de confirmation et les messages d'erreur. De plus, la liste des bénéficiaires masque correctement les actions non autorisées (ajout, import) lorsque le groupe « Tous » est sélectionné, même si une seule organisation du projet est en mode anonyme.