### PR TITLE
Add confirmation status indicators in managers table

### DIFF
--- a/Sig.App.Frontend/src/components/managers/managers-table.vue
+++ b/Sig.App.Frontend/src/components/managers/managers-table.vue
@@ -10,6 +10,8 @@
           "confirmation-link-copied": "Confirmation link copied to clipboard.",
           "copy-reset-password-email": "Copy reset password link",
           "confirmation-reset-password-link-copied": "Reset password link copied to clipboard.",
+          "confirmed": "✔️ Confirmed",
+          "not-confirmed": "❌ Not confirmed",
       },
       "fr": {
           "options": "Options",
@@ -20,7 +22,9 @@
           "resend-complete": "Un message pour compléter la création de compte a été envoyé à {email}.",
           "confirmation-link-copied": "Lien de confirmation copié dans le presse-papiers.",
           "copy-reset-password-email": "Copier le lien de réinitialisation du mot de passe",
-          "confirmation-reset-password-link-copied": "Lien de réinitialisation du mot de passe copié dans le presse-papiers."
+          "confirmation-reset-password-link-copied": "Lien de réinitialisation du mot de passe copié dans le presse-papiers.",
+          "confirmed": "✔️ Confirmé",
+          "not-confirmed": "❌ Non confirmé",
       }
   }
 </i18n>
@@ -31,7 +35,11 @@
       <td>
         <p v-if="getUserName(slotProps.item)" class="mb-0">{{ getUserName(slotProps.item) }}</p>
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <p v-if="slotProps.item.email" class="mb-0 text-p4" v-html="getUserEmail(slotProps.item)"></p>
+        <p v-if="slotProps.item.email" class="mb-0 text-p4">
+          <span v-if="slotProps.item.isConfirmed">{{ t("confirmed") }}</span>
+          <span v-else>{{ t("not-confirmed") }}</span>
+          - <span v-html="getUserEmail(slotProps.item)"></span>
+        </p>
       </td>
       <td>
         <UiButtonGroup :items="getBtnGroup(slotProps.item)" tooltip-position="left" />


### PR DESCRIPTION
## [JIRA Indiquer si un compte a été vérifié ou pas #209](https://sigmund-ca.atlassian.net/browse/CRCL-2412)
 
### Contexte
Dans le tableau des gestionnaires, il n'était pas possible de savoir visuellement si un compte était confirmé ou non sans passer par les options de la ligne (qui montraient ou cachaient les boutons de renvoi de courriel). Les administrateurs n'avaient aucun indicateur direct à la lecture du tableau.

### Modifications
**Tableau des gestionnaires**
- Ajout d'un indicateur de confirmation (✔️ Confirmé / ❌ Non confirmé) directement dans la cellule du nom, affiché avant l'adresse courriel.

### Comportement
À la lecture du tableau des gestionnaires, chaque ligne affiche maintenant l'état de confirmation du compte directement sous le nom, avec l'adresse courriel. L'indicateur est purement visuel et en lecture seule ; les actions (renvoi de courriel, copie du lien) restent accessibles via le menu d'options habituel.

### Images
<img width="1280" height="1392" alt="Capture d’écran 2026-05-06 163003" src="https://github.com/user-attachments/assets/a80e89c0-5fa8-4116-b6f4-507fa48de0dc" />
