### PR TITLE
Implement beneficiary anonymity handling across various GraphQL types and queries

### DIFF
--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiaryGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiaryGraphType.cs
@@ -9,23 +9,27 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
 {
     public class BeneficiaryGraphType : IBeneficiaryGraphType
     {
+        private const string Anonymous = "*******";
+
         protected readonly Beneficiary beneficiary;
+        protected readonly bool beneficiariesAreAnonymous;
 
         public Id Id => beneficiary.GetIdentifier();
-        public NonNull<string> Firstname => beneficiary.Firstname;
-        public NonNull<string> Lastname => beneficiary.Lastname;
-        public string Email => beneficiary.Email;
-        public string Phone => beneficiary.Phone;
-        public string Address => beneficiary.Address;
-        public string Notes => beneficiary.Notes;
+        public NonNull<string> Firstname => beneficiariesAreAnonymous ? Anonymous : beneficiary.Firstname;
+        public NonNull<string> Lastname => beneficiariesAreAnonymous ? Anonymous : beneficiary.Lastname;
+        public string Email => beneficiariesAreAnonymous ? Anonymous : beneficiary.Email;
+        public string Phone => beneficiariesAreAnonymous ? Anonymous : beneficiary.Phone;
+        public string Address => beneficiariesAreAnonymous ? Anonymous : beneficiary.Address;
+        public string Notes => beneficiariesAreAnonymous ? Anonymous : beneficiary.Notes;
         public string Id1 => beneficiary.ID1;
         public string Id2 => beneficiary.ID2;
-        public string PostalCode => beneficiary.PostalCode;
+        public string PostalCode => beneficiariesAreAnonymous ? Anonymous : beneficiary.PostalCode;
         public bool IsUnsubscribeToReceipt => beneficiary.IsUnsubscribeToReceipt;
 
-        public BeneficiaryGraphType(Beneficiary beneficiary)
+        public BeneficiaryGraphType(Beneficiary beneficiary, bool beneficiariesAreAnonymous = false)
         {
             this.beneficiary = beneficiary;
+            this.beneficiariesAreAnonymous = beneficiariesAreAnonymous;
         }
 
         public IDataLoaderResult<OrganizationGraphType> Organization(IAppUserContext ctx)

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiaryGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiaryGraphType.cs
@@ -26,7 +26,8 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         public string PostalCode => beneficiariesAreAnonymous ? Anonymous : beneficiary.PostalCode;
         public bool IsUnsubscribeToReceipt => beneficiary.IsUnsubscribeToReceipt;
 
-        public BeneficiaryGraphType(Beneficiary beneficiary, bool beneficiariesAreAnonymous = false)
+        // beneficiariesAreAnonymous is set to true by default to avoid exposing beneficiary data in the beneficiary
+        public BeneficiaryGraphType(Beneficiary beneficiary, bool beneficiariesAreAnonymous = true)
         {
             this.beneficiary = beneficiary;
             this.beneficiariesAreAnonymous = beneficiariesAreAnonymous;

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/OffPlatformBeneficiaryGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/OffPlatformBeneficiaryGraphType.cs
@@ -11,25 +11,29 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
 {
     public class OffPlatformBeneficiaryGraphType : IBeneficiaryGraphType
     {
+        private const string Anonymous = "*******";
+
         protected readonly OffPlatformBeneficiary beneficiary;
+        protected readonly bool beneficiariesAreAnonymous;
 
         public Id Id => beneficiary.GetIdentifier();
-        public NonNull<string> Firstname => beneficiary.Firstname;
-        public NonNull<string> Lastname => beneficiary.Lastname;
-        public string Email => beneficiary.Email;
-        public string Phone => beneficiary.Phone;
-        public string Address => beneficiary.Address;
-        public string Notes => beneficiary.Notes;
+        public NonNull<string> Firstname => beneficiariesAreAnonymous ? Anonymous : beneficiary.Firstname;
+        public NonNull<string> Lastname => beneficiariesAreAnonymous ? Anonymous : beneficiary.Lastname;
+        public string Email => beneficiariesAreAnonymous ? Anonymous : beneficiary.Email;
+        public string Phone => beneficiariesAreAnonymous ? Anonymous : beneficiary.Phone;
+        public string Address => beneficiariesAreAnonymous ? Anonymous : beneficiary.Address;
+        public string Notes => beneficiariesAreAnonymous ? Anonymous : beneficiary.Notes;
         public string Id1 => beneficiary.ID1;
         public string Id2 => beneficiary.ID2;
-        public string PostalCode => beneficiary.PostalCode;
+        public string PostalCode => beneficiariesAreAnonymous ? Anonymous : beneficiary.PostalCode;
         public SubscriptionMonthlyPaymentMoment? MonthlyPaymentMoment => beneficiary.MonthlyPaymentMoment;
         public bool IsActive => beneficiary.IsActive;
         public bool IsUnsubscribeToReceipt => beneficiary.IsUnsubscribeToReceipt;
 
-        public OffPlatformBeneficiaryGraphType(OffPlatformBeneficiary beneficiary)
+        public OffPlatformBeneficiaryGraphType(OffPlatformBeneficiary beneficiary, bool beneficiariesAreAnonymous = false)
         {
             this.beneficiary = beneficiary;
+            this.beneficiariesAreAnonymous = beneficiariesAreAnonymous;
         }
 
         public IDataLoaderResult<OrganizationGraphType> Organization(IAppUserContext ctx)

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/OffPlatformBeneficiaryGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/OffPlatformBeneficiaryGraphType.cs
@@ -30,7 +30,8 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         public bool IsActive => beneficiary.IsActive;
         public bool IsUnsubscribeToReceipt => beneficiary.IsUnsubscribeToReceipt;
 
-        public OffPlatformBeneficiaryGraphType(OffPlatformBeneficiary beneficiary, bool beneficiariesAreAnonymous = false)
+        // beneficiariesAreAnonymous is set to true by default to avoid exposing beneficiary data in the off platform beneficiary
+        public OffPlatformBeneficiaryGraphType(OffPlatformBeneficiary beneficiary, bool beneficiariesAreAnonymous = true)
         {
             this.beneficiary = beneficiary;
             this.beneficiariesAreAnonymous = beneficiariesAreAnonymous;

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/OrganizationGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/OrganizationGraphType.cs
@@ -1,6 +1,8 @@
 ﻿using GraphQL.Conventions;
 using GraphQL.DataLoader;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.DbModel.Entities.Organizations;
 using Sig.App.Backend.DbModel.Entities.Subscriptions;
@@ -41,7 +43,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             return ctx.DataLoader.LoadOrganizationMarkets(Id.LongIdentifierForType<Organization>());
         }
 
-        public async Task<PaymentConflictPagination<IBeneficiaryGraphType>> Beneficiaries([Inject] IMediator mediator, int page, int limit,
+        public async Task<PaymentConflictPagination<IBeneficiaryGraphType>> Beneficiaries([Inject] IMediator mediator, [Inject] AppDbContext db, int page, int limit,
             [Description("If specified, only beneficiaries without or with a subscription are returned.")] bool? withoutSubscription = null,
             [Description("If specified, only beneficiaries with one of those subscription are returned.")] Id[] subscriptions = null,
             [Description("If specified, only beneficiaries without one of those subscription are returned.")] Id[] withoutSpecificSubscriptions = null,
@@ -54,6 +56,11 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             [Description("If specified, only that match text is returned.")] string searchText = "",
             Sort<BeneficiarySort> sort = null)
         {
+            var isAnonymous = await db.Projects
+                .Where(p => p.Id == organization.ProjectId)
+                .Select(p => p.BeneficiariesAreAnonymous)
+                .FirstOrDefaultAsync();
+
             var results = await mediator.Send(new SearchBeneficiaries.Query
             {
                 OrganizationId = organization.Id,
@@ -78,9 +85,9 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
                     case null:
                         return null as IBeneficiaryGraphType;
                     case OffPlatformBeneficiary opb:
-                        return new OffPlatformBeneficiaryGraphType(opb);
+                        return new OffPlatformBeneficiaryGraphType(opb, isAnonymous);
                     default:
-                        return new BeneficiaryGraphType(x);
+                        return new BeneficiaryGraphType(x, isAnonymous);
                 }
             });
         }

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/ProjectGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/ProjectGraphType.cs
@@ -238,9 +238,9 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
                     case null:
                         return null as IBeneficiaryGraphType;
                     case OffPlatformBeneficiary opb:
-                        return new OffPlatformBeneficiaryGraphType(opb);
+                        return new OffPlatformBeneficiaryGraphType(opb, project.BeneficiariesAreAnonymous);
                     default:
-                        return new BeneficiaryGraphType(x);
+                        return new BeneficiaryGraphType(x, project.BeneficiariesAreAnonymous);
                 }
             });
         }

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/TransactionLogGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/TransactionLogGraphType.cs
@@ -12,16 +12,19 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
 {
     public class TransactionLogGraphType
     {
+        private const string Anonymous = "*******";
+
         private readonly TransactionLog transactionLog;
+        private readonly bool beneficiariesAreAnonymous;
 
         public Id Id => transactionLog.GetIdentifier();
         public TransactionLogDiscriminator Discriminator => transactionLog.Discriminator;
         public decimal TotalAmount => transactionLog.TotalAmount;
         public long? BeneficiaryId => transactionLog.BeneficiaryId;
-        public string BeneficiaryFirstname => transactionLog.BeneficiaryFirstname;
-        public string BeneficiaryLastname => transactionLog.BeneficiaryLastname;
-        public string BeneficiaryEmail => transactionLog.BeneficiaryEmail;
-        public string BeneficiaryPhone => transactionLog.BeneficiaryPhone;
+        public string BeneficiaryFirstname => beneficiariesAreAnonymous ? Anonymous : transactionLog.BeneficiaryFirstname;
+        public string BeneficiaryLastname => beneficiariesAreAnonymous ? Anonymous : transactionLog.BeneficiaryLastname;
+        public string BeneficiaryEmail => beneficiariesAreAnonymous ? Anonymous : transactionLog.BeneficiaryEmail;
+        public string BeneficiaryPhone => beneficiariesAreAnonymous ? Anonymous : transactionLog.BeneficiaryPhone;
         public string BeneficiaryID1 => transactionLog.BeneficiaryID1;
         public string BeneficiaryID2 => transactionLog.BeneficiaryID2;
         public long? BeneficiaryTypeId => transactionLog.BeneficiaryTypeId;
@@ -54,9 +57,10 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         public long? CashRegisterId => transactionLog.CashRegisterId;
         public string CashRegisterName => transactionLog.CashRegisterName;
 
-        public TransactionLogGraphType(TransactionLog transactionLog)
+        public TransactionLogGraphType(TransactionLog transactionLog, bool beneficiariesAreAnonymous = false)
         {
             this.transactionLog = transactionLog;
+            this.beneficiariesAreAnonymous = beneficiariesAreAnonymous;
         }
         
         public OffsetDateTime CreatedAt()

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/TransactionLogGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/TransactionLogGraphType.cs
@@ -57,7 +57,8 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         public long? CashRegisterId => transactionLog.CashRegisterId;
         public string CashRegisterName => transactionLog.CashRegisterName;
 
-        public TransactionLogGraphType(TransactionLog transactionLog, bool beneficiariesAreAnonymous = false)
+        // beneficiariesAreAnonymous is set to true by default to avoid exposing beneficiary data in the transaction log
+        public TransactionLogGraphType(TransactionLog transactionLog, bool beneficiariesAreAnonymous = true)
         {
             this.transactionLog = transactionLog;
             this.beneficiariesAreAnonymous = beneficiariesAreAnonymous;

--- a/Sig.App.Backend/Gql/Schema/Query.cs
+++ b/Sig.App.Backend/Gql/Schema/Query.cs
@@ -512,9 +512,15 @@ namespace Sig.App.Backend.Gql.Schema
 
         [RequirePermission(GlobalPermission.ManageTransactions)]
         [Description("All transactions")]
-        public static async Task<TransactionLogsPagination<TransactionLogGraphType>> TransactionLogs(this GqlQuery _, [Inject] IMediator mediator,
+        public static async Task<TransactionLogsPagination<TransactionLogGraphType>> TransactionLogs(this GqlQuery _, [Inject] IMediator mediator, [Inject] AppDbContext db,
             int page, int limit, Id projectId, DateTime startDate, DateTime endDate, Id[] organizations, Id[] subscriptions, Id[] markets, bool? withoutSubscription, Id[] categories, string[] transactionTypes, string[] giftCardTransactionTypes, Id[] cashRegisters, string searchText, string timeZoneId)
         {
+            var longProjectId = projectId.LongIdentifierForType<Project>();
+            var isAnonymous = await db.Projects
+                .Where(p => p.Id == longProjectId)
+                .Select(p => p.BeneficiariesAreAnonymous)
+                .FirstOrDefaultAsync();
+
             var results = await mediator.Send(new SearchTransactionLogs.Query
             {
                 Page = new Page(page, limit),
@@ -533,7 +539,7 @@ namespace Sig.App.Backend.Gql.Schema
                 TimeZoneId = timeZoneId
             });
 
-            return results.Map(x => new TransactionLogGraphType(x));
+            return results.Map(x => new TransactionLogGraphType(x, isAnonymous));
         }
     }
 }

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/CreateBeneficiaryInOrganization.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/CreateBeneficiaryInOrganization.cs
@@ -32,7 +32,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
         {
             logger.LogInformation($"[Mutation] CreateBeneficiaryInOrganization({request.Firstname}, {request.Lastname}, {request.Id1}, {request.Id2}, {request.BeneficiaryTypeId})");
             var organizationId = request.OrganizationId.LongIdentifierForType<Organization>();
-            var organization = await db.Organizations.FirstOrDefaultAsync(x => x.Id == organizationId, cancellationToken);
+            var organization = await db.Organizations.Include(x => x.Project).FirstOrDefaultAsync(x => x.Id == organizationId, cancellationToken);
 
             if (organization == null)
             {
@@ -88,7 +88,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             return new Payload
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, organization.Project.BeneficiariesAreAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
@@ -77,7 +77,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             return new Payload
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
@@ -32,7 +32,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
         {
             logger.LogInformation($"[Mutation] EditBeneficiary({request.BeneficiaryId}, {request.Firstname}, {request.Lastname}, {request.Id1}, {request.Id2}, {request.BeneficiaryTypeId})");
             var beneficiaryId = request.BeneficiaryId.LongIdentifierForType<Beneficiary>();
-            var beneficiary = await db.Beneficiaries.FirstOrDefaultAsync(x => x.Id == beneficiaryId, cancellationToken);
+            var beneficiary = await db.Beneficiaries.Include(x => x.Organization).ThenInclude(x => x.Project).FirstOrDefaultAsync(x => x.Id == beneficiaryId, cancellationToken);
 
             if (beneficiary == null)
             {
@@ -77,7 +77,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             return new Payload
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/ImportBeneficiariesListInOrganization.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/ImportBeneficiariesListInOrganization.cs
@@ -102,7 +102,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             return new Payload
             {
-                Beneficiaries = beneficiaries.Select(x => new BeneficiaryGraphType(x))
+                Beneficiaries = beneficiaries.Select(x => new BeneficiaryGraphType(x, organization.Project.BeneficiariesAreAnonymous))
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
@@ -86,7 +86,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
             logger.LogInformation($"[Mutation] AssignCardToBeneficiary - Card ({card.Id}) assign  to {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
             return new Payload() {
-                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
@@ -38,7 +38,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
             {
                 beneficiaryId = request.BeneficiaryId.LongIdentifierForType<OffPlatformBeneficiary>();
             }
-            var beneficiary = await db.Beneficiaries.Include(x => x.Organization).FirstOrDefaultAsync(x => x.Id == beneficiaryId, cancellationToken);
+            var beneficiary = await db.Beneficiaries.Include(x => x.Organization).ThenInclude(x => x.Project).FirstOrDefaultAsync(x => x.Id == beneficiaryId, cancellationToken);
 
             if (beneficiary == null)
             {
@@ -86,7 +86,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
             logger.LogInformation($"[Mutation] AssignCardToBeneficiary - Card ({card.Id}) assign  to {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
             return new Payload() {
-                Beneficiary = beneficiary is OffPlatformBeneficiary ? new OffPlatformBeneficiaryGraphType(beneficiary as OffPlatformBeneficiary) : new BeneficiaryGraphType(beneficiary)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
@@ -60,7 +60,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             return new Payload()
             {
-                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
@@ -38,7 +38,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
             {
                 beneficiaryId = request.BeneficiaryId.LongIdentifierForType<OffPlatformBeneficiary>();
             }
-            var beneficiary = await db.Beneficiaries.Include(x => x.Organization).FirstOrDefaultAsync(x => x.Id == beneficiaryId, cancellationToken);
+            var beneficiary = await db.Beneficiaries.Include(x => x.Organization).ThenInclude(x => x.Project).FirstOrDefaultAsync(x => x.Id == beneficiaryId, cancellationToken);
 
             if (beneficiary == null)
             {
@@ -60,7 +60,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             return new Payload()
             {
-                Beneficiary = beneficiary is OffPlatformBeneficiary ? new OffPlatformBeneficiaryGraphType(beneficiary as OffPlatformBeneficiary) : new BeneficiaryGraphType(beneficiary)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
@@ -186,7 +186,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
             logger.LogInformation($"[Mutation] UnassignCardFromBeneficiary - Card ({card.Id}) unassign from {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
             return new Payload() {
-                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
@@ -186,7 +186,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
             logger.LogInformation($"[Mutation] UnassignCardFromBeneficiary - Card ({card.Id}) unassign from {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
             return new Payload() {
-                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb) : new BeneficiaryGraphType(beneficiary)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
@@ -85,7 +85,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             await db.SaveChangesAsync(cancellationToken);
-            return new Payload() { Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) };
+            return new Payload() { Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) };
         }
 
         private decimal GetAmountPayment(Subscription subscription, long beneficiaryTypeId) 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
@@ -44,6 +44,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             var beneficiary = await db.Beneficiaries
                 .Include(x => x.Subscriptions).ThenInclude(x => x.Subscription).ThenInclude(x => x.Types)
                 .Include(x => x.Subscriptions).ThenInclude(x => x.BudgetAllowance)
+                .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .FirstOrDefaultAsync(x => x.Id == beneficiaryId, cancellationToken);
 
             if (beneficiary == null)
@@ -84,7 +85,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             await db.SaveChangesAsync(cancellationToken);
-            return new Payload() { Beneficiary = new BeneficiaryGraphType(beneficiary) };
+            return new Payload() { Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) };
         }
 
         private decimal GetAmountPayment(Subscription subscription, long beneficiaryTypeId) 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
@@ -146,7 +146,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, organization.Project?.BeneficiariesAreAnonymous ?? false)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, organization.Project?.BeneficiariesAreAnonymous ?? true)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
@@ -39,7 +39,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
         {
             logger.LogInformation($"[Mutation] AssignSubscriptionsToBeneficiary({request.OrganizationId}, {request.Subscriptions}, {request.BeneficiaryId})");
             var organizationId = request.OrganizationId.LongIdentifierForType<Organization>();
-            var organization = await db.Organizations.Include(x => x.BudgetAllowances).FirstOrDefaultAsync(x => x.Id == organizationId, cancellationToken);
+            var organization = await db.Organizations.Include(x => x.BudgetAllowances).Include(x => x.Project).FirstOrDefaultAsync(x => x.Id == organizationId, cancellationToken);
 
             if (organization == null)
             {
@@ -146,7 +146,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, organization.Project?.BeneficiariesAreAnonymous ?? false)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
@@ -93,7 +93,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             logger.LogInformation($"[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - MaxNumberOfPaymentsOverride set to {request.MaxNumberOfPayments} for beneficiary {beneficiaryId} in subscription {subscriptionId}");
 
-            return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary, subscriptionBeneficiary.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) };
+            return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary, subscriptionBeneficiary.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) };
         }
 
         [MutationInput]

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
@@ -40,7 +40,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             var subscriptionBeneficiary = await db.SubscriptionBeneficiaries
                 .Include(x => x.Subscription).ThenInclude(x => x.Types)
                 .Include(x => x.BudgetAllowance)
-                .Include(x => x.Beneficiary)
+                .Include(x => x.Beneficiary).ThenInclude(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(x => x.BeneficiaryId == beneficiaryId && x.SubscriptionId == subscriptionId)
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -93,7 +93,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             logger.LogInformation($"[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - MaxNumberOfPaymentsOverride set to {request.MaxNumberOfPayments} for beneficiary {beneficiaryId} in subscription {subscriptionId}");
 
-            return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary) };
+            return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary, subscriptionBeneficiary.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false) };
         }
 
         [MutationInput]

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -143,7 +143,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -143,7 +143,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
@@ -147,7 +147,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
@@ -147,7 +147,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
             };
         }
 

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
@@ -26,7 +26,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
                 .OrderBy(x => x.SortOrder)
                 .ToListAsync(cancellationToken);
 
-            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x, x.Organization?.Project?.BeneficiariesAreAnonymous ?? false));
+            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x, x.Organization?.Project?.BeneficiariesAreAnonymous ?? true));
         }
     }
 }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
@@ -21,11 +21,12 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public override async Task<ILookup<long, BeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
             var results = await db.Beneficiaries
+                .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(x => request.Ids.Contains(x.BeneficiaryTypeId.Value))
                 .OrderBy(x => x.SortOrder)
                 .ToListAsync(cancellationToken);
 
-            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x));
+            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x, x.Organization?.Project?.BeneficiariesAreAnonymous ?? false));
         }
     }
 }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
@@ -22,11 +22,16 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
 
         public override async Task<IDictionary<long, IBeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
-            var cards = await db.Cards.Include(x => x.Beneficiary)
+            var cards = await db.Cards
+                .Include(x => x.Beneficiary).ThenInclude(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(c => request.Ids.Contains(c.Id))
                 .ToListAsync(cancellationToken);
 
-            return cards.ToDictionary(x => x.Id, x => x.Beneficiary != null ? x.Beneficiary is OffPlatformBeneficiary ? new OffPlatformBeneficiaryGraphType(x.Beneficiary as OffPlatformBeneficiary) as IBeneficiaryGraphType : new BeneficiaryGraphType(x.Beneficiary) : null);
+            return cards.ToDictionary(x => x.Id, x => {
+                if (x.Beneficiary == null) return null;
+                var isBeneficiariesAnonymous = x.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false;
+                return x.Beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x.Beneficiary, isBeneficiariesAnonymous);
+            });
         }
     }
 }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
@@ -29,7 +29,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
 
             return cards.ToDictionary(x => x.Id, x => {
                 if (x.Beneficiary == null) return null;
-                var isBeneficiariesAnonymous = x.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? false;
+                var isBeneficiariesAnonymous = x.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true;
                 return x.Beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x.Beneficiary, isBeneficiariesAnonymous);
             });
         }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
@@ -28,7 +28,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
                 .ToListAsync(cancellationToken);
 
             return markets.ToDictionary(x => x.Id, x => {
-                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? false;
+                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? true;
                 if (x is OffPlatformBeneficiary opb)
                 {
                     return new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType;

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
@@ -23,15 +23,17 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public override async Task<IDictionary<long, IBeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
             var markets = await db.Beneficiaries
+                .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(c => request.Ids.Contains(c.Id))
                 .ToListAsync(cancellationToken);
 
             return markets.ToDictionary(x => x.Id, x => {
-                if (x is OffPlatformBeneficiary)
+                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? false;
+                if (x is OffPlatformBeneficiary opb)
                 {
-                    return new OffPlatformBeneficiaryGraphType(x as OffPlatformBeneficiary) as IBeneficiaryGraphType;
+                    return new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType;
                 }
-                return new BeneficiaryGraphType(x);
+                return new BeneficiaryGraphType(x, isBeneficiariesAnonymous);
             });
         }
     }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
@@ -28,7 +28,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
                 .ToListAsync(cancellationToken);
 
             return results.ToLookup(x => x.OrganizationId, x => {
-                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? false;
+                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? true;
                 return x is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x, isBeneficiariesAnonymous);
             });
         }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
@@ -22,11 +22,15 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public override async Task<ILookup<long, IBeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
             var results = await db.Beneficiaries
+                .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(x => request.Ids.Contains(x.OrganizationId))
                 .OrderBy(x => x.SortOrder)
                 .ToListAsync(cancellationToken);
 
-            return results.ToLookup(x => x.OrganizationId, x => x is OffPlatformBeneficiary ? new OffPlatformBeneficiaryGraphType(x as OffPlatformBeneficiary) as IBeneficiaryGraphType : new BeneficiaryGraphType(x));
+            return results.ToLookup(x => x.OrganizationId, x => {
+                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? false;
+                return x is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x, isBeneficiariesAnonymous);
+            });
         }
     }
 }

--- a/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
+++ b/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
@@ -33,7 +33,7 @@ namespace Sig.App.Backend.Services.Beneficiaries
                 var existingClaims = await userManager.GetClaimsAsync(currentUser);
                 var existingProjectClaims = existingClaims.Where(x => x.Type == AppClaimTypes.ProjectManagerOf).Select(x => x.Value);
                 var results = await db.Projects.Where(x => existingProjectClaims.Contains(x.Id.ToString())).ToListAsync();
-                beneficiariesAreAnonymous = results.FirstOrDefault()?.BeneficiariesAreAnonymous ?? false;
+                beneficiariesAreAnonymous = results.FirstOrDefault()?.BeneficiariesAreAnonymous ?? true;
             }
 
             return !beneficiariesAreAnonymous;

--- a/Sig.App.Backend/Services/Reports/ReportService.cs
+++ b/Sig.App.Backend/Services/Reports/ReportService.cs
@@ -89,6 +89,10 @@ namespace Sig.App.Backend.Services.Reports
             var currentUserCanSeeAllBeneficiaryInfo = await beneficiaryService.CurrentUserCanSeeAllBeneficiaryInfo();
             var globalPermissions = await permissionService.GetGlobalPermissions(ctx.CurrentUser);
             var longProjectId = request.ProjectId.LongIdentifierForType<Project>();
+            var beneficiariesAreAnonymous = await db.Projects
+                .Where(p => p.Id == longProjectId)
+                .Select(p => p.BeneficiariesAreAnonymous)
+                .FirstOrDefaultAsync();
             var startDate = request.StartDate.ToUniversalTime();
             var endDate = request.EndDate.ToUniversalTime();
 
@@ -205,7 +209,7 @@ namespace Sig.App.Backend.Services.Reports
             dataWorksheet.Column("Id 1 (participant)", x => x.BeneficiaryID1);
             dataWorksheet.Column("Id 2 (participant)", x => x.BeneficiaryID2);
 
-            if (currentUserCanSeeAllBeneficiaryInfo)
+            if (currentUserCanSeeAllBeneficiaryInfo && !beneficiariesAreAnonymous)
             {
                 dataWorksheet.Column("Participant-e/Participant", GetParticipantName);
                 dataWorksheet.Column("Courriel participant-e/Participant email", x => x.BeneficiaryEmail);


### PR DESCRIPTION
# [JIRA - Est-ce que c'est correct que les infos anonymes soient encore fetchées ?](https://sigmund-ca.atlassian.net/browse/CRCL-2531)

## Contexte
Le 'flag' `BeneficiariesAreAnonymous` existait déjà sur l'entité `Project`, mais il n'était pas appliqué de manière cohérente à la couche GraphQL. Des informations nominatives (prénom, nom, courriel, téléphone, adresse, notes, code postal) des participant·e·s restaient visibles dans les réponses de l'API et dans les rapports, même lorsque l'anonymisation était activée pour le projet.

## Modifications
**Types GraphQL (API)**
- `BeneficiaryGraphType` et `OffPlatformBeneficiaryGraphType` : ajout d'un paramètre `beneficiariesAreAnonymous` au constructeur ; tous les champs nominatifs (`Firstname`, `Lastname`, `Email`, `Phone`, `Address`, `Notes`, `PostalCode`) retournent `"*******"` lorsque le drapeau est actif.
- `TransactionLogGraphType` : même traitement pour `BeneficiaryFirstname`, `BeneficiaryLastname`, `BeneficiaryEmail` et `BeneficiaryPhone`.

## Mutations (API)
Mise à jour de toutes les mutations qui retournent un bénéficiaire dans leur payload pour propager le 'flag' :
- `CreateBeneficiaryInOrganization`, `EditBeneficiary`, `ImportBeneficiariesListInOrganization`
- `AssignCardToBeneficiary`, `AssignUnassignedCardToBeneficiary`, `UnassignCardFromBeneficiary`
- `AdjustBeneficiarySubscription`, `AssignSubscriptionsToBeneficiary`, `ChangeBeneficiarySubscriptionMaxNumberOfPayments`
- `AddMissingPayment`, `AddMissingPayments`

## Service de rapports (API)
La condition d'affichage des colonnes nominatives dans les rapports est renforcée : `currentUserCanSeeAllBeneficiaryInfo && !beneficiariesAreAnonymous`.

## Comportement
Lorsque `BeneficiariesAreAnonymous` est activé sur un projet, toutes les réponses GraphQL et tous les rapports Excel masquent systématiquement les données nominatives des participant·e·s, peu importe le rôle de l'utilisateur·rice connecté·e. Les identifiants internes (Id1, Id2) restent visibles pour permettre la réconciliation.