### PR TITLE
Fix handling for subscription payments starting on the fifteenth day of the month

### DIFF
--- a/Sig.App.Backend/Helpers/SubscriptionHelper.cs
+++ b/Sig.App.Backend/Helpers/SubscriptionHelper.cs
@@ -52,6 +52,7 @@ namespace Sig.App.Backend.Helpers
                 subscription.MonthlyPaymentMoment == SubscriptionMonthlyPaymentMoment.FirstAndFifteenthDayOfTheMonth)
             {
                 cardPaymentRemaining += AdjustedMonthsForFifteenth(startDate, endDate);
+                if (startDate > today && startDate.Day == 15) cardPaymentRemaining++;
             }
 
             if (needExtraDay) cardPaymentRemaining++;

--- a/Sig.App.Backend/Helpers/SubscriptionHelper.cs
+++ b/Sig.App.Backend/Helpers/SubscriptionHelper.cs
@@ -52,7 +52,7 @@ namespace Sig.App.Backend.Helpers
                 subscription.MonthlyPaymentMoment == SubscriptionMonthlyPaymentMoment.FirstAndFifteenthDayOfTheMonth)
             {
                 cardPaymentRemaining += AdjustedMonthsForFifteenth(startDate, endDate);
-                if (startDate > today && startDate.Day == 15) cardPaymentRemaining++;
+                if (startDate > today && startDate.Day == 15) needExtraDay = true;
             }
 
             if (needExtraDay) cardPaymentRemaining++;

--- a/Sig.App.BackendTests/Helpers/SubscriptionHelperTests.cs
+++ b/Sig.App.BackendTests/Helpers/SubscriptionHelperTests.cs
@@ -285,6 +285,40 @@ namespace Sig.App.BackendTests.Helpers
         }
 
         [Fact]
+        public void GetPaymentRemaining_FirstAndFifteenth_StartingOnFifteenthBeforeStart()
+        {
+            Clock.Reset(Instant.FromUtc(2026, 5, 12, 0, 0));
+
+            var subscription = new Subscription
+            {
+                StartDate = new DateTime(2026, 6, 15),
+                EndDate = new DateTime(2026, 9, 20),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstAndFifteenthDayOfTheMonth,
+                IsSubscriptionPaymentBasedCardUsage = false
+            };
+
+            var result = subscription.GetPaymentRemaining(Clock);
+            result.Should().Be(7);
+        }
+
+        [Fact]
+        public void GetPaymentRemaining_FifteenthDay_StartingOnFifteenthBeforeStart()
+        {
+            Clock.Reset(Instant.FromUtc(2026, 5, 12, 0, 0));
+
+            var subscription = new Subscription
+            {
+                StartDate = new DateTime(2026, 6, 15),
+                EndDate = new DateTime(2026, 9, 20),
+                MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth,
+                IsSubscriptionPaymentBasedCardUsage = false
+            };
+
+            var result = subscription.GetPaymentRemaining(Clock);
+            result.Should().Be(4);
+        }
+
+        [Fact]
         public void GetPaymentRemaining_FirstAndFifteenthDayOfTheMonth_JustBeforeStartButAndOfPreviousMonth()
         {
             Clock.Reset(Instant.FromUtc(2025, 5, 31, 0, 0));


### PR DESCRIPTION
# [JIRA - Nombre incorrect de versements restants en attribuant un abonnement #245](https://sigmund-ca.atlassian.net/browse/CRCL-2533)

Il y avait du code pour régler ce problème lorsqu'un abonnement commençait le 1 jour, mais pas le 15.