### PR TITLE
Refactor beneficiary data handling to improve anonymity checks and allow GroupManager to always see the BeneficiaryData (even when the project is Anonymous).

### DIFF
--- a/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiaryGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/BeneficiaryGraphType.cs
@@ -26,7 +26,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         public string PostalCode => beneficiariesAreAnonymous ? Anonymous : beneficiary.PostalCode;
         public bool IsUnsubscribeToReceipt => beneficiary.IsUnsubscribeToReceipt;
 
-        // beneficiariesAreAnonymous is set to true by default to avoid exposing beneficiary data in the beneficiary
+        // defaults to true as a safety measure; callers should use BeneficiaryService.ShouldAnonymizeBeneficiaries()
         public BeneficiaryGraphType(Beneficiary beneficiary, bool beneficiariesAreAnonymous = true)
         {
             this.beneficiary = beneficiary;

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/OffPlatformBeneficiaryGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/OffPlatformBeneficiaryGraphType.cs
@@ -30,7 +30,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
         public bool IsActive => beneficiary.IsActive;
         public bool IsUnsubscribeToReceipt => beneficiary.IsUnsubscribeToReceipt;
 
-        // beneficiariesAreAnonymous is set to true by default to avoid exposing beneficiary data in the off platform beneficiary
+        // defaults to true as a safety measure; callers should use BeneficiaryService.ShouldAnonymizeBeneficiaries()
         public OffPlatformBeneficiaryGraphType(OffPlatformBeneficiary beneficiary, bool beneficiariesAreAnonymous = true)
         {
             this.beneficiary = beneficiary;

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/OrganizationGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/OrganizationGraphType.cs
@@ -57,11 +57,10 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             [Description("If specified, only that match text is returned.")] string searchText = "",
             Sort<BeneficiarySort> sort = null)
         {
-            var projectIsAnonymous = await db.Projects
+            var project = await db.Projects
                 .Where(p => p.Id == organization.ProjectId)
-                .Select(p => p.BeneficiariesAreAnonymous)
                 .FirstOrDefaultAsync();
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(projectIsAnonymous);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(project);
 
             var results = await mediator.Send(new SearchBeneficiaries.Query
             {

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/OrganizationGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/OrganizationGraphType.cs
@@ -12,6 +12,7 @@ using Sig.App.Backend.Gql.Bases;
 using Sig.App.Backend.Gql.Interfaces;
 using Sig.App.Backend.Requests.Queries.Beneficiaries;
 using Sig.App.Backend.Requests.Queries.Organizations;
+using Sig.App.Backend.Services.Beneficiaries;
 using Sig.App.Backend.Utilities;
 using Sig.App.Backend.Utilities.Sorting;
 using System;
@@ -43,7 +44,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             return ctx.DataLoader.LoadOrganizationMarkets(Id.LongIdentifierForType<Organization>());
         }
 
-        public async Task<PaymentConflictPagination<IBeneficiaryGraphType>> Beneficiaries([Inject] IMediator mediator, [Inject] AppDbContext db, int page, int limit,
+        public async Task<PaymentConflictPagination<IBeneficiaryGraphType>> Beneficiaries([Inject] IMediator mediator, [Inject] AppDbContext db, [Inject] IBeneficiaryService beneficiaryService, int page, int limit,
             [Description("If specified, only beneficiaries without or with a subscription are returned.")] bool? withoutSubscription = null,
             [Description("If specified, only beneficiaries with one of those subscription are returned.")] Id[] subscriptions = null,
             [Description("If specified, only beneficiaries without one of those subscription are returned.")] Id[] withoutSpecificSubscriptions = null,
@@ -56,10 +57,11 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             [Description("If specified, only that match text is returned.")] string searchText = "",
             Sort<BeneficiarySort> sort = null)
         {
-            var isAnonymous = await db.Projects
+            var projectIsAnonymous = await db.Projects
                 .Where(p => p.Id == organization.ProjectId)
                 .Select(p => p.BeneficiariesAreAnonymous)
                 .FirstOrDefaultAsync();
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(projectIsAnonymous);
 
             var results = await mediator.Send(new SearchBeneficiaries.Query
             {

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/ProjectGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/ProjectGraphType.cs
@@ -232,7 +232,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
                 WithCardDisabled = withCardDisabled
             });
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(project.BeneficiariesAreAnonymous);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(project);
             return results.Map(x =>
             {
                 switch (x)

--- a/Sig.App.Backend/Gql/Schema/GraphTypes/ProjectGraphType.cs
+++ b/Sig.App.Backend/Gql/Schema/GraphTypes/ProjectGraphType.cs
@@ -17,6 +17,7 @@ using Sig.App.Backend.Requests.Queries.Cards;
 using Sig.App.Backend.Requests.Queries.Markets;
 using Sig.App.Backend.Requests.Queries.Organizations;
 using Sig.App.Backend.Requests.Queries.Projects;
+using Sig.App.Backend.Services.Beneficiaries;
 using Sig.App.Backend.Services.Permission.Enums;
 using Sig.App.Backend.Utilities;
 using Sig.App.Backend.Utilities.Sorting;
@@ -201,7 +202,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
             });
         }
 
-        public async Task<PaymentConflictPagination<IBeneficiaryGraphType>> Beneficiaries([Inject] IMediator mediator, int page, int limit,
+        public async Task<PaymentConflictPagination<IBeneficiaryGraphType>> Beneficiaries([Inject] IMediator mediator, [Inject] IBeneficiaryService beneficiaryService, int page, int limit,
             [Description("If specified, only beneficiaries without or with a subscription are returned.")] bool? withoutSubscription = null,
             [Description("If specified, only beneficiaries with one of those subscription are returned.")] Id[] subscriptions = null,
             [Description("If specified, only beneficiaries without one of those subscription are returned.")] Id[] withoutSpecificSubscriptions = null,
@@ -231,6 +232,7 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
                 WithCardDisabled = withCardDisabled
             });
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(project.BeneficiariesAreAnonymous);
             return results.Map(x =>
             {
                 switch (x)
@@ -238,9 +240,9 @@ namespace Sig.App.Backend.Gql.Schema.GraphTypes
                     case null:
                         return null as IBeneficiaryGraphType;
                     case OffPlatformBeneficiary opb:
-                        return new OffPlatformBeneficiaryGraphType(opb, project.BeneficiariesAreAnonymous);
+                        return new OffPlatformBeneficiaryGraphType(opb, isAnonymous);
                     default:
-                        return new BeneficiaryGraphType(x, project.BeneficiariesAreAnonymous);
+                        return new BeneficiaryGraphType(x, isAnonymous);
                 }
             });
         }

--- a/Sig.App.Backend/Gql/Schema/Query.cs
+++ b/Sig.App.Backend/Gql/Schema/Query.cs
@@ -1,48 +1,49 @@
 ﻿using GraphQL.Conventions;
+using GraphQL.DataLoader;
+using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using System;
-using System.Threading.Tasks;
-using MediatR;
-using GraphQL.DataLoader;
 using Sig.App.Backend.Authorization;
 using Sig.App.Backend.Constants;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities;
+using Sig.App.Backend.DbModel.Entities.Beneficiaries;
+using Sig.App.Backend.DbModel.Entities.BudgetAllowances;
+using Sig.App.Backend.DbModel.Entities.Cards;
+using Sig.App.Backend.DbModel.Entities.CashRegisters;
+using Sig.App.Backend.DbModel.Entities.MarketGroups;
+using Sig.App.Backend.DbModel.Entities.Markets;
+using Sig.App.Backend.DbModel.Entities.Organizations;
+using Sig.App.Backend.DbModel.Entities.ProductGroups;
+using Sig.App.Backend.DbModel.Entities.Projects;
+using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Entities.Transactions;
+using Sig.App.Backend.DbModel.Enums;
+using Sig.App.Backend.Extensions;
+using Sig.App.Backend.Gql.Bases;
 using Sig.App.Backend.Gql.Interfaces;
 using Sig.App.Backend.Gql.Schema.Enums;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Gql.Schema.Types;
-using Sig.App.Backend.Requests.Queries.Users;
-using Sig.App.Backend.Services.Permission.Enums;
-using Sig.App.Backend.Utilities;
-using System.Collections.Generic;
-using System.Linq;
-using Sig.App.Backend.Extensions;
-using Sig.App.Backend.DbModel.Entities.Projects;
-using Sig.App.Backend.DbModel.Entities.Organizations;
-using Sig.App.Backend.DbModel.Entities.Markets;
-using Sig.App.Backend.DbModel.Entities.Beneficiaries;
-using Sig.App.Backend.Services.Permission;
-using Sig.App.Backend.DbModel.Entities.Cards;
-using Sig.App.Backend.Requests.Queries.Cards;
 using Sig.App.Backend.Plugins.GraphQL;
-using Sig.App.Backend.DbModel.Entities.Transactions;
-using Sig.App.Backend.DbModel.Entities.Subscriptions;
-using Sig.App.Backend.DbModel.Entities.BudgetAllowances;
+using Sig.App.Backend.Requests.Commands.Queries.Beneficiaries;
 using Sig.App.Backend.Requests.Commands.Queries.Cards;
 using Sig.App.Backend.Requests.Commands.Queries.Transactions;
-using Sig.App.Backend.Requests.Queries.Transactions;
-using Sig.App.Backend.Requests.Commands.Queries.Beneficiaries;
-using Sig.App.Backend.DbModel.Entities.ProductGroups;
-using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.Requests.Queries.Beneficiaries;
-using Sig.App.Backend.Gql.Bases;
-using Sig.App.Backend.Utilities.Sorting;
-using Sig.App.Backend.DbModel.Entities.MarketGroups;
+using Sig.App.Backend.Requests.Queries.Cards;
 using Sig.App.Backend.Requests.Queries.Markets;
-using Sig.App.Backend.DbModel.Entities.CashRegisters;
+using Sig.App.Backend.Requests.Queries.Transactions;
+using Sig.App.Backend.Requests.Queries.Users;
+using Sig.App.Backend.Services.Beneficiaries;
+using Sig.App.Backend.Services.Permission;
+using Sig.App.Backend.Services.Permission.Enums;
+using Sig.App.Backend.Utilities;
+using Sig.App.Backend.Utilities.Sorting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Sig.App.Backend.Gql.Schema
 {
@@ -512,14 +513,15 @@ namespace Sig.App.Backend.Gql.Schema
 
         [RequirePermission(GlobalPermission.ManageTransactions)]
         [Description("All transactions")]
-        public static async Task<TransactionLogsPagination<TransactionLogGraphType>> TransactionLogs(this GqlQuery _, [Inject] IMediator mediator, [Inject] AppDbContext db,
+        public static async Task<TransactionLogsPagination<TransactionLogGraphType>> TransactionLogs(this GqlQuery _, [Inject] IMediator mediator, [Inject] AppDbContext db, [Inject] IBeneficiaryService beneficiaryService,
             int page, int limit, Id projectId, DateTime startDate, DateTime endDate, Id[] organizations, Id[] subscriptions, Id[] markets, bool? withoutSubscription, Id[] categories, string[] transactionTypes, string[] giftCardTransactionTypes, Id[] cashRegisters, string searchText, string timeZoneId)
         {
             var longProjectId = projectId.LongIdentifierForType<Project>();
-            var isAnonymous = await db.Projects
+
+            var project = await db.Projects
                 .Where(p => p.Id == longProjectId)
-                .Select(p => p.BeneficiariesAreAnonymous)
                 .FirstOrDefaultAsync();
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(project);
 
             var results = await mediator.Send(new SearchTransactionLogs.Query
             {

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/CreateBeneficiaryInOrganization.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/CreateBeneficiaryInOrganization.cs
@@ -89,7 +89,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             logger.LogInformation($"[Mutation] CreateBeneficiaryInOrganization - New beneficiary created {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project.BeneficiariesAreAnonymous);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project);
             return new Payload
             {
                 Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/CreateBeneficiaryInOrganization.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/CreateBeneficiaryInOrganization.cs
@@ -10,6 +10,7 @@ using Sig.App.Backend.Gql.Bases;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using Sig.App.Backend.Services.Beneficiaries;
 using System;
 using System.Linq;
 using System.Threading;
@@ -21,11 +22,13 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
     {
         private readonly ILogger<CreateBeneficiaryInOrganization> logger;
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public CreateBeneficiaryInOrganization(ILogger<CreateBeneficiaryInOrganization> logger, AppDbContext db)
+        public CreateBeneficiaryInOrganization(ILogger<CreateBeneficiaryInOrganization> logger, AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -86,9 +89,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             logger.LogInformation($"[Mutation] CreateBeneficiaryInOrganization - New beneficiary created {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project.BeneficiariesAreAnonymous);
             return new Payload
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, organization.Project.BeneficiariesAreAnonymous)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
@@ -78,7 +78,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             logger.LogInformation($"[Mutation] EditBeneficiary - Beneficiary edited {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project);
             return new Payload
             {
                 Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiary.cs
@@ -10,6 +10,7 @@ using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Gql.Schema.Types;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using Sig.App.Backend.Services.Beneficiaries;
 using System;
 using System.Linq;
 using System.Threading;
@@ -21,11 +22,13 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
     {
         private readonly ILogger<EditBeneficiary> logger;
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public EditBeneficiary(ILogger<EditBeneficiary> logger, AppDbContext db)
+        public EditBeneficiary(ILogger<EditBeneficiary> logger, AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -75,9 +78,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             logger.LogInformation($"[Mutation] EditBeneficiary - Beneficiary edited {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
             return new Payload
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/ImportBeneficiariesListInOrganization.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/ImportBeneficiariesListInOrganization.cs
@@ -103,7 +103,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             await db.SaveChangesAsync(cancellationToken);
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project.BeneficiariesAreAnonymous);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project);
             return new Payload
             {
                 Beneficiaries = beneficiaries.Select(x => new BeneficiaryGraphType(x, isAnonymous))

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/ImportBeneficiariesListInOrganization.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/ImportBeneficiariesListInOrganization.cs
@@ -10,6 +10,7 @@ using Sig.App.Backend.Gql.Bases;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using Sig.App.Backend.Services.Beneficiaries;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,11 +23,13 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
     {
         private readonly ILogger<ImportBeneficiariesListInOrganization> logger;
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public ImportBeneficiariesListInOrganization(ILogger<ImportBeneficiariesListInOrganization> logger, AppDbContext db)
+        public ImportBeneficiariesListInOrganization(ILogger<ImportBeneficiariesListInOrganization> logger, AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -100,9 +103,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
             await db.SaveChangesAsync(cancellationToken);
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project.BeneficiariesAreAnonymous);
             return new Payload
             {
-                Beneficiaries = beneficiaries.Select(x => new BeneficiaryGraphType(x, organization.Project.BeneficiariesAreAnonymous))
+                Beneficiaries = beneficiaries.Select(x => new BeneficiaryGraphType(x, isAnonymous))
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
@@ -10,6 +10,7 @@ using Sig.App.Backend.Gql.Bases;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using Sig.App.Backend.Services.Beneficiaries;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,11 +20,13 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
     {
         private readonly ILogger<AssignCardToBeneficiary> logger;
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public AssignCardToBeneficiary(ILogger<AssignCardToBeneficiary> logger, AppDbContext db)
+        public AssignCardToBeneficiary(ILogger<AssignCardToBeneficiary> logger, AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -85,8 +88,9 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             logger.LogInformation($"[Mutation] AssignCardToBeneficiary - Card ({card.Id}) assign  to {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
             return new Payload() {
-                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isAnonymous) : new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignCardToBeneficiary.cs
@@ -88,7 +88,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             logger.LogInformation($"[Mutation] AssignCardToBeneficiary - Card ({card.Id}) assign  to {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project);
             return new Payload() {
                 Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isAnonymous) : new BeneficiaryGraphType(beneficiary, isAnonymous)
             };

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
@@ -10,6 +10,7 @@ using Sig.App.Backend.Gql.Bases;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using Sig.App.Backend.Services.Beneficiaries;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,11 +20,13 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
     {
         private readonly ILogger<AssignUnassignedCardToBeneficiary> logger;
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public AssignUnassignedCardToBeneficiary(ILogger<AssignUnassignedCardToBeneficiary> logger, AppDbContext db)
+        public AssignUnassignedCardToBeneficiary(ILogger<AssignUnassignedCardToBeneficiary> logger, AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -58,9 +61,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             await db.SaveChangesAsync();
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
             return new Payload()
             {
-                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isAnonymous) : new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/AssignUnassignedCardToBeneficiary.cs
@@ -61,7 +61,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             await db.SaveChangesAsync();
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project);
             return new Payload()
             {
                 Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isAnonymous) : new BeneficiaryGraphType(beneficiary, isAnonymous)

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
@@ -188,7 +188,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             logger.LogInformation($"[Mutation] UnassignCardFromBeneficiary - Card ({card.Id}) unassign from {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project);
             return new Payload() {
                 Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isAnonymous) : new BeneficiaryGraphType(beneficiary, isAnonymous)
             };

--- a/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Cards/UnassignCardFromBeneficiary.cs
@@ -19,6 +19,7 @@ using NodaTime;
 using Sig.App.Backend.DbModel.Entities.TransactionLogs;
 using Sig.App.Backend.Helpers;
 using Sig.App.Backend.Gql.Bases;
+using Sig.App.Backend.Services.Beneficiaries;
 
 namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 {
@@ -28,13 +29,15 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
         private readonly AppDbContext db;
         private readonly IClock clock;
         private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public UnassignCardFromBeneficiary(ILogger<UnassignCardFromBeneficiary> logger, AppDbContext db, IClock clock, IHttpContextAccessor httpContextAccessor)
+        public UnassignCardFromBeneficiary(ILogger<UnassignCardFromBeneficiary> logger, AppDbContext db, IClock clock, IHttpContextAccessor httpContextAccessor, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
             this.clock = clock;
             this.httpContextAccessor = httpContextAccessor;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -185,8 +188,9 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Cards
 
             logger.LogInformation($"[Mutation] UnassignCardFromBeneficiary - Card ({card.Id}) unassign from {beneficiary.Firstname} {beneficiary.Lastname} ({beneficiary.Id})");
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
             return new Payload() {
-                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) : new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
+                Beneficiary = beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isAnonymous) : new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
@@ -88,7 +88,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             await db.SaveChangesAsync(cancellationToken);
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project);
             return new Payload() { Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous) };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
@@ -12,6 +12,7 @@ using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Helpers;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using Sig.App.Backend.Services.Beneficiaries;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,12 +26,14 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
         private readonly ILogger<AdjustBeneficiarySubscription> logger;
         private readonly IClock clock;
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public AdjustBeneficiarySubscription(ILogger<AdjustBeneficiarySubscription> logger, IClock clock, AppDbContext db)
+        public AdjustBeneficiarySubscription(ILogger<AdjustBeneficiarySubscription> logger, IClock clock, AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.clock = clock;
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -85,7 +88,8 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
             }
 
             await db.SaveChangesAsync(cancellationToken);
-            return new Payload() { Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) };
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            return new Payload() { Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous) };
         }
 
         private decimal GetAmountPayment(Subscription subscription, long beneficiaryTypeId) 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
@@ -19,20 +19,23 @@ using System.Threading.Tasks;
 using Sig.App.Backend.Gql.Bases;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using Sig.App.Backend.Services.Beneficiaries;
 
 namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 {
     public class AssignSubscriptionsToBeneficiary : IRequestHandler<AssignSubscriptionsToBeneficiary.Input, AssignSubscriptionsToBeneficiary.Payload>
     {
         private readonly ILogger<AssignSubscriptionsToBeneficiary> logger;
-        private IClock clock;
+        private readonly IClock clock;
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public AssignSubscriptionsToBeneficiary(ILogger<AssignSubscriptionsToBeneficiary> logger, IClock clock, AppDbContext db)
+        public AssignSubscriptionsToBeneficiary(ILogger<AssignSubscriptionsToBeneficiary> logger, IClock clock, AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.clock = clock;
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -144,9 +147,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             await db.SaveChangesAsync(cancellationToken);
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project?.BeneficiariesAreAnonymous ?? true);
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, organization.Project?.BeneficiariesAreAnonymous ?? true)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AssignSubscriptionsToBeneficiary.cs
@@ -147,7 +147,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             await db.SaveChangesAsync(cancellationToken);
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(organization.Project);
             return new Payload()
             {
                 Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
@@ -96,7 +96,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             logger.LogInformation($"[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - MaxNumberOfPaymentsOverride set to {request.MaxNumberOfPayments} for beneficiary {beneficiaryId} in subscription {subscriptionId}");
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(subscriptionBeneficiary.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(subscriptionBeneficiary.Beneficiary.Organization?.Project);
             return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary, isAnonymous) };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/ChangeBeneficiarySubscriptionMaxNumberOfPayments.cs
@@ -11,6 +11,7 @@ using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.Helpers;
 using Sig.App.Backend.Plugins.GraphQL;
 using Sig.App.Backend.Plugins.MediatR;
+using Sig.App.Backend.Services.Beneficiaries;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,12 +23,14 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
         private readonly ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger;
         private readonly AppDbContext db;
         private readonly IClock clock;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public ChangeBeneficiarySubscriptionMaxNumberOfPayments(ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger, AppDbContext db, IClock clock)
+        public ChangeBeneficiarySubscriptionMaxNumberOfPayments(ILogger<ChangeBeneficiarySubscriptionMaxNumberOfPayments> logger, AppDbContext db, IClock clock, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
             this.clock = clock;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -93,7 +96,8 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
 
             logger.LogInformation($"[Mutation] ChangeBeneficiarySubscriptionMaxNumberOfPayments - MaxNumberOfPaymentsOverride set to {request.MaxNumberOfPayments} for beneficiary {beneficiaryId} in subscription {subscriptionId}");
 
-            return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary, subscriptionBeneficiary.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true) };
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(subscriptionBeneficiary.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            return new Payload { Beneficiary = new BeneficiaryGraphType(subscriptionBeneficiary.Beneficiary, isAnonymous) };
         }
 
         [MutationInput]

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -144,7 +144,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             await db.SaveChangesAsync(cancellationToken);
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project);
             return new Payload()
             {
                 Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayment.cs
@@ -17,6 +17,7 @@ using Sig.App.Backend.Helpers;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.BackgroundJobs;
 using Sig.App.Backend.DbModel.Entities.Transactions;
+using Sig.App.Backend.Services.Beneficiaries;
 using System;
 
 namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
@@ -28,14 +29,16 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
         private readonly IClock clock;
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly ILogger<AddingFundToCard> addingFundLogger;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public AddMissingPayment(ILogger<AddMissingPayment> logger, AppDbContext db, IClock clock, IHttpContextAccessor httpContextAccessor, ILogger<AddingFundToCard> addingFundLogger)
+        public AddMissingPayment(ILogger<AddMissingPayment> logger, AppDbContext db, IClock clock, IHttpContextAccessor httpContextAccessor, ILogger<AddingFundToCard> addingFundLogger, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
             this.clock = clock;
             this.httpContextAccessor = httpContextAccessor;
             this.addingFundLogger = addingFundLogger;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -141,9 +144,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             await db.SaveChangesAsync(cancellationToken);
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
@@ -17,6 +17,7 @@ using Sig.App.Backend.Helpers;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
 using Sig.App.Backend.BackgroundJobs;
 using Sig.App.Backend.DbModel.Entities.Transactions;
+using Sig.App.Backend.Services.Beneficiaries;
 using System.Collections.Generic;
 using System;
 
@@ -29,14 +30,16 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
         private readonly IClock clock;
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly ILogger<AddingFundToCard> addingFundLogger;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public AddMissingPayments(ILogger<AddMissingPayments> logger, AppDbContext db, IClock clock, IHttpContextAccessor httpContextAccessor, ILogger<AddingFundToCard> addingFundLogger)
+        public AddMissingPayments(ILogger<AddMissingPayments> logger, AppDbContext db, IClock clock, IHttpContextAccessor httpContextAccessor, ILogger<AddingFundToCard> addingFundLogger, IBeneficiaryService beneficiaryService)
         {
             this.logger = logger;
             this.db = db;
             this.clock = clock;
             this.httpContextAccessor = httpContextAccessor;
             this.addingFundLogger = addingFundLogger;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public async Task<Payload> Handle(Input request, CancellationToken cancellationToken)
@@ -145,9 +148,10 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             await db.SaveChangesAsync(cancellationToken);
 
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
             return new Payload()
             {
-                Beneficiary = new BeneficiaryGraphType(beneficiary, beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true)
+                Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)
             };
         }
 

--- a/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Transactions/AddMissingPayments.cs
@@ -148,7 +148,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Transactions
 
             await db.SaveChangesAsync(cancellationToken);
 
-            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+            var isAnonymous = await beneficiaryService.ShouldAnonymizeBeneficiaries(beneficiary.Organization?.Project);
             return new Payload()
             {
                 Beneficiary = new BeneficiaryGraphType(beneficiary, isAnonymous)

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
@@ -31,7 +31,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
                 .OrderBy(x => x.SortOrder)
                 .ToListAsync(cancellationToken);
 
-            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x, !canSeeAll && (x.Organization?.Project?.BeneficiariesAreAnonymous ?? true)));
+            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x, beneficiaryService.ShouldAnonymizeBeneficiaries(x.Organization?.Project, canSeeAll)));
         }
     }
 }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiariesByBeneficiaryTypeId.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
+using Sig.App.Backend.Services.Beneficiaries;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,21 +13,25 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public class Query : BaseQuery { }
 
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public GetBeneficiariesByBeneficiaryTypeId(AppDbContext db)
+        public GetBeneficiariesByBeneficiaryTypeId(AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public override async Task<ILookup<long, BeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
+            var canSeeAll = await beneficiaryService.CurrentUserCanSeeAllBeneficiaryInfo();
+
             var results = await db.Beneficiaries
                 .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(x => request.Ids.Contains(x.BeneficiaryTypeId.Value))
                 .OrderBy(x => x.SortOrder)
                 .ToListAsync(cancellationToken);
 
-            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x, x.Organization?.Project?.BeneficiariesAreAnonymous ?? true));
+            return results.ToLookup(x => x.BeneficiaryTypeId.Value, x => new BeneficiaryGraphType(x, !canSeeAll && (x.Organization?.Project?.BeneficiariesAreAnonymous ?? true)));
         }
     }
 }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
@@ -34,7 +34,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
 
             return cards.ToDictionary(x => x.Id, x => {
                 if (x.Beneficiary == null) return null;
-                var isBeneficiariesAnonymous = !canSeeAll && (x.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+                var isBeneficiariesAnonymous = beneficiaryService.ShouldAnonymizeBeneficiaries(x.Beneficiary.Organization?.Project, canSeeAll);
                 return x.Beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x.Beneficiary, isBeneficiariesAnonymous);
             });
         }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByCardIds.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
+using Sig.App.Backend.Services.Beneficiaries;
 
 namespace Sig.App.Backend.Requests.Queries.DataLoaders
 {
@@ -14,14 +15,18 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public class Query : BaseQuery { }
 
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public GetBeneficiaryByCardIds(AppDbContext db)
+        public GetBeneficiaryByCardIds(AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public override async Task<IDictionary<long, IBeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
+            var canSeeAll = await beneficiaryService.CurrentUserCanSeeAllBeneficiaryInfo();
+
             var cards = await db.Cards
                 .Include(x => x.Beneficiary).ThenInclude(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(c => request.Ids.Contains(c.Id))
@@ -29,7 +34,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
 
             return cards.ToDictionary(x => x.Id, x => {
                 if (x.Beneficiary == null) return null;
-                var isBeneficiariesAnonymous = x.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true;
+                var isBeneficiariesAnonymous = !canSeeAll && (x.Beneficiary.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
                 return x.Beneficiary is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x.Beneficiary, isBeneficiariesAnonymous);
             });
         }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
+using Sig.App.Backend.Services.Beneficiaries;
 
 namespace Sig.App.Backend.Requests.Queries.DataLoaders
 {
@@ -14,21 +15,25 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public class Query : BaseQuery { }
 
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public GetBeneficiaryByIds(AppDbContext db)
+        public GetBeneficiaryByIds(AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public override async Task<IDictionary<long, IBeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
+            var canSeeAll = await beneficiaryService.CurrentUserCanSeeAllBeneficiaryInfo();
+
             var markets = await db.Beneficiaries
                 .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(c => request.Ids.Contains(c.Id))
                 .ToListAsync(cancellationToken);
 
             return markets.ToDictionary(x => x.Id, x => {
-                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? true;
+                var isBeneficiariesAnonymous = !canSeeAll && (x.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
                 if (x is OffPlatformBeneficiary opb)
                 {
                     return new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType;

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByIds.cs
@@ -33,7 +33,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
                 .ToListAsync(cancellationToken);
 
             return markets.ToDictionary(x => x.Id, x => {
-                var isBeneficiariesAnonymous = !canSeeAll && (x.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+                var isBeneficiariesAnonymous = beneficiaryService.ShouldAnonymizeBeneficiaries(x.Organization?.Project, canSeeAll);
                 if (x is OffPlatformBeneficiary opb)
                 {
                     return new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType;

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.Gql.Schema.GraphTypes;
+using Sig.App.Backend.Services.Beneficiaries;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,14 +14,18 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
         public class Query : BaseQuery { }
 
         private readonly AppDbContext db;
+        private readonly IBeneficiaryService beneficiaryService;
 
-        public GetBeneficiaryByOrganizationId(AppDbContext db)
+        public GetBeneficiaryByOrganizationId(AppDbContext db, IBeneficiaryService beneficiaryService)
         {
             this.db = db;
+            this.beneficiaryService = beneficiaryService;
         }
 
         public override async Task<ILookup<long, IBeneficiaryGraphType>> Handle(Query request, CancellationToken cancellationToken)
         {
+            var canSeeAll = await beneficiaryService.CurrentUserCanSeeAllBeneficiaryInfo();
+
             var results = await db.Beneficiaries
                 .Include(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(x => request.Ids.Contains(x.OrganizationId))
@@ -28,7 +33,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
                 .ToListAsync(cancellationToken);
 
             return results.ToLookup(x => x.OrganizationId, x => {
-                var isBeneficiariesAnonymous = x.Organization?.Project?.BeneficiariesAreAnonymous ?? true;
+                var isBeneficiariesAnonymous = !canSeeAll && (x.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
                 return x is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x, isBeneficiariesAnonymous);
             });
         }

--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetBeneficiaryByOrganizationId.cs
@@ -33,7 +33,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
                 .ToListAsync(cancellationToken);
 
             return results.ToLookup(x => x.OrganizationId, x => {
-                var isBeneficiariesAnonymous = !canSeeAll && (x.Organization?.Project?.BeneficiariesAreAnonymous ?? true);
+                var isBeneficiariesAnonymous = beneficiaryService.ShouldAnonymizeBeneficiaries(x.Organization?.Project, canSeeAll);
                 return x is OffPlatformBeneficiary opb ? new OffPlatformBeneficiaryGraphType(opb, isBeneficiariesAnonymous) as IBeneficiaryGraphType : new BeneficiaryGraphType(x, isBeneficiariesAnonymous);
             });
         }

--- a/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
+++ b/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
@@ -28,11 +28,6 @@ namespace Sig.App.Backend.Services.Beneficiaries
         {
             var beneficiariesAreAnonymous = false;
             var currentUser = await currentUserAccessor.GetCurrentUser();
-            
-            if (currentUser.Type == UserType.OrganizationManager)
-            {
-                return true;
-            }
 
             if (currentUser.Type == UserType.ProjectManager)
             {
@@ -45,11 +40,16 @@ namespace Sig.App.Backend.Services.Beneficiaries
             return !beneficiariesAreAnonymous;
         }
 
-        public async Task<bool> ShouldAnonymizeBeneficiaries(Project? project)
+        public bool ShouldAnonymizeBeneficiaries(Project? project, bool canSeeAll)
         {
             if (project == null) return true;
             if (!project.BeneficiariesAreAnonymous) return false;
-            return !await CurrentUserCanSeeAllBeneficiaryInfo();
+            return !canSeeAll;
+        }
+
+        public async Task<bool> ShouldAnonymizeBeneficiaries(Project? project)
+        {
+            return ShouldAnonymizeBeneficiaries(project, await CurrentUserCanSeeAllBeneficiaryInfo());
         }
     }
 }

--- a/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
+++ b/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
@@ -28,6 +28,11 @@ namespace Sig.App.Backend.Services.Beneficiaries
             var beneficiariesAreAnonymous = false;
             var currentUser = await currentUserAccessor.GetCurrentUser();
             
+            if (currentUser.Type == UserType.OrganizationManager)
+            {
+                return true;
+            }
+
             if (currentUser.Type == UserType.ProjectManager)
             {
                 var existingClaims = await userManager.GetClaimsAsync(currentUser);
@@ -37,6 +42,12 @@ namespace Sig.App.Backend.Services.Beneficiaries
             }
 
             return !beneficiariesAreAnonymous;
+        }
+
+        public async Task<bool> ShouldAnonymizeBeneficiaries(bool projectBeneficiariesAreAnonymous)
+        {
+            if (!projectBeneficiariesAreAnonymous) return false;
+            return !await CurrentUserCanSeeAllBeneficiaryInfo();
         }
     }
 }

--- a/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
+++ b/Sig.App.Backend/Services/Beneficiaries/BeneficiaryService.cs
@@ -6,6 +6,7 @@ using Sig.App.Backend.Constants;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.DbModel.Entities;
 using Sig.App.Backend.DbModel.Enums;
+using Sig.App.Backend.DbModel.Entities.Projects;
 using Sig.App.Backend.Services.System;
 
 namespace Sig.App.Backend.Services.Beneficiaries
@@ -44,9 +45,10 @@ namespace Sig.App.Backend.Services.Beneficiaries
             return !beneficiariesAreAnonymous;
         }
 
-        public async Task<bool> ShouldAnonymizeBeneficiaries(bool projectBeneficiariesAreAnonymous)
+        public async Task<bool> ShouldAnonymizeBeneficiaries(Project? project)
         {
-            if (!projectBeneficiariesAreAnonymous) return false;
+            if (project == null) return true;
+            if (!project.BeneficiariesAreAnonymous) return false;
             return !await CurrentUserCanSeeAllBeneficiaryInfo();
         }
     }

--- a/Sig.App.Backend/Services/Beneficiaries/IBeneficiaryService.cs
+++ b/Sig.App.Backend/Services/Beneficiaries/IBeneficiaryService.cs
@@ -6,6 +6,7 @@ namespace Sig.App.Backend.Services.Beneficiaries
     public interface IBeneficiaryService
     {
         Task<bool> CurrentUserCanSeeAllBeneficiaryInfo();
+        bool ShouldAnonymizeBeneficiaries(Project? project, bool canSeeAll);
         Task<bool> ShouldAnonymizeBeneficiaries(Project? project);
     }
 }

--- a/Sig.App.Backend/Services/Beneficiaries/IBeneficiaryService.cs
+++ b/Sig.App.Backend/Services/Beneficiaries/IBeneficiaryService.cs
@@ -5,5 +5,6 @@ namespace Sig.App.Backend.Services.Beneficiaries
     public interface IBeneficiaryService
     {
         Task<bool> CurrentUserCanSeeAllBeneficiaryInfo();
+        Task<bool> ShouldAnonymizeBeneficiaries(bool projectBeneficiariesAreAnonymous);
     }
 }

--- a/Sig.App.Backend/Services/Beneficiaries/IBeneficiaryService.cs
+++ b/Sig.App.Backend/Services/Beneficiaries/IBeneficiaryService.cs
@@ -1,10 +1,11 @@
 ﻿using System.Threading.Tasks;
+using Sig.App.Backend.DbModel.Entities.Projects;
 
 namespace Sig.App.Backend.Services.Beneficiaries
 {
     public interface IBeneficiaryService
     {
         Task<bool> CurrentUserCanSeeAllBeneficiaryInfo();
-        Task<bool> ShouldAnonymizeBeneficiaries(bool projectBeneficiariesAreAnonymous);
+        Task<bool> ShouldAnonymizeBeneficiaries(Project? project);
     }
 }


### PR DESCRIPTION
# [JIRA - Les infos personnelles sont masquées pour un compte gestionnaire de groupe de participant·e·s dans un programme anonyme #248](https://sigmund-ca.atlassian.net/browse/CRCL-2537)

C'était une erreur dans la gestion de l'anonymisation. En gros, on cache maintenant les données au niveau backend. Par contre, il y avait une distinction entre le FE et le BE. Les gestionnaires de groupe on toujours le droit de voir les données, même lorsque le projet est Anonymisé.