### PR TITLE
Fix empty merchant transaction history when refund predates date range (CRCL-2538)

### DIFF
--- a/Sig.App.Backend/Requests/Queries/DataLoaders/GetMarketTransactions.cs
+++ b/Sig.App.Backend/Requests/Queries/DataLoaders/GetMarketTransactions.cs
@@ -36,6 +36,7 @@ namespace Sig.App.Backend.Requests.Queries.DataLoaders
             var paymentTransactions = await paymentQuery.ToListAsync(cancellationToken);
 
             var refundQuery = db.Transactions.OfType<RefundTransaction>()
+                .Include(x => x.InitialTransaction)
                 .Where(c => request.Ids.Contains(c.InitialTransaction.MarketId) && c.CreatedAtUtc >= startUtc && c.CreatedAtUtc < endUtc);
             if (cashRegisterIds.Length > 0)
                 refundQuery = refundQuery.Where(c => c.InitialTransaction.CashRegisterId.HasValue && cashRegisterIds.Contains(c.InitialTransaction.CashRegisterId.Value));

--- a/Sig.App.Frontend/src/views/transaction/MarketListTransaction.vue
+++ b/Sig.App.Frontend/src/views/transaction/MarketListTransaction.vue
@@ -107,6 +107,7 @@ import { useCashRegisterStore } from "@/lib/store/cash-register";
 
 import { LANG_EN } from "@/lib/consts/langs";
 import { LANGUAGE_FILTER_EN, LANGUAGE_FILTER_FR } from "@/lib/consts/enums";
+import ICON_DOWNLOAD from "@/lib/icons/download.json";
 
 const dateFrom = ref(new Date(Date.now()));
 const dateTo = ref(new Date(Date.now()));


### PR DESCRIPTION
# [JIRA - Rapport de transactions ne charge pas correctement pour un commerce](https://sigmund-ca.atlassian.net/browse/CRCL-2538)

Lorsqu'un **gestionnaire de commerce** consulte son historique de transactions (`/market-transactions`) pour certaines plages de dates, la liste reste vide et une erreur GraphQL apparaît.

| Plage de dates | Résultat (avant correctif) |
|----------------|----------------------------|
| 20 mai → 20 mai | Vide |
| 19 mai → 21 mai | Vide |
| 18 mai → 21 mai | Fonctionne |

Le problème **ne se reproduit pas** pour un **gestionnaire de programme**, qui utilise une autre requête (`transactionLogs`) et une autre source de données.

**Scénario déclencheur typique :** un remboursement effectué plusieurs jours après l'achat initial (ex. achat le 18 mai, remboursement le 20 mai par un gestionnaire de programme). Dès que la plage commence **après** la date d'achat mais **inclut** la date du remboursement, la vue commerce échoue.

## Cause racine

Deux chemins distincts côté frontend :

| Rôle | Vue | Requête GraphQL | Source |
|------|-----|-----------------|--------|
| Gestionnaire de commerce | `MarketListTransaction.vue` | `markets { transactions(...) }` | `GetMarketTransactions` |
| Gestionnaire de programme | `ListTransactions.vue` | `transactionLogs` | `TransactionLogs` |

Le bug se situe dans `GetMarketTransactions.cs` :

1. Les **paiements** sont filtrés par `CreatedAtUtc` dans la plage choisie.
2. Les **remboursements** sont filtrés par date du remboursement, mais regroupés via `refund.InitialTransaction.MarketId`.
3. La requête des remboursements **n'incluait pas** `.Include(x => x.InitialTransaction)`.
4. EF ne peuple `InitialTransaction` que si le paiement initial est déjà chargé dans le même contexte (même plage de dates).
5. Remboursement dans la plage, paiement initial hors plage → `NullReferenceException` au regroupement → erreur GraphQL → page vide.

`GetMarketGroupTransactions.cs` appliquait déjà correctement `.Include(x => x.InitialTransaction)`.

## Correctif

- Ajout de `.Include(x => x.InitialTransaction)` sur la requête des remboursements dans `GetMarketTransactions.cs`.
- Import manquant de `ICON_DOWNLOAD` dans `MarketListTransaction.vue` (avertissement console Vue sur le bouton « Exporter un rapport »).

## Reproduction locale

**Données minimales à simuler :**

- Un **paiement** à la date D (ex. 18 mai).
- Un **remboursement** lié à ce paiement à la date D+2 (ex. 20 mai).
- Des paiements additionnels entre D+1 et D+3.

**Étapes :**

1. Se connecter comme **gestionnaire de commerce** (`outils+merchant1@sigmund.ca` en dev).
2. Aller sur **Historique des transactions** (`/market-transactions`).
3. **Avant correctif :** plage **19–21 mai** → liste vide + erreur GraphQL ; plage **18–21 mai** → transactions visibles.
4. **Après correctif :** plage **19–21 mai** → transactions visibles (paiements + remboursement).

**Contrôle :** gestionnaire de programme sur la même plage → inchangé (non affecté).

## Test plan

- [ ] Gestionnaire commerce, plage incluant le remboursement mais pas le paiement initial → liste affichée, pas d'erreur GraphQL
- [ ] Gestionnaire commerce, plage incluant paiement initial et remboursement → liste affichée (régression)
- [ ] Gestionnaire commerce, plage sans transaction → message « Aucune transaction » (pas d'erreur)
- [ ] Filtre par caisse → résultats cohérents pour paiements et remboursements
- [ ] Gestionnaire programme → historique inchangé
- [ ] Pas d'avertissement `ICON_DOWNLOAD` dans la console sur `/market-transactions`
