### PR TITLE
Replace cash register filter with market group filter on transactions page (CRCL-2522)

### DIFF
--- a/Sig.App.Backend/Gql/Schema/Query.cs
+++ b/Sig.App.Backend/Gql/Schema/Query.cs
@@ -387,7 +387,7 @@ namespace Sig.App.Backend.Gql.Schema
             });
         }
 
-        public static async Task<string> GenerateTransactionsReport(this GqlQuery _, Id projectId, DateTime startDate, DateTime endDate, Id[] organizations, Id[] subscriptions, bool? withoutSubscription, Id[] categories, Id[] markets, Id[] cashRegisters, string[] transactionTypes, string[] giftCardTransactionTypes, string searchText, string timeZoneId, Language language, [Inject] IMediator mediator)
+        public static async Task<string> GenerateTransactionsReport(this GqlQuery _, Id projectId, DateTime startDate, DateTime endDate, Id[] organizations, Id[] subscriptions, bool? withoutSubscription, Id[] categories, Id[] markets, Id[] marketGroups, string[] transactionTypes, string[] giftCardTransactionTypes, string searchText, string timeZoneId, Language language, [Inject] IMediator mediator)
         {
             return await mediator.Send(new GenerateTransactionsReport.Input()
             {
@@ -397,7 +397,7 @@ namespace Sig.App.Backend.Gql.Schema
                 Organizations = organizations,
                 Subscriptions = subscriptions,
                 Markets = markets,
-                CashRegisters = cashRegisters,
+                MarketGroups = marketGroups,
                 WithoutSubscription = withoutSubscription,
                 Categories = categories,
                 TransactionTypes = transactionTypes,
@@ -513,7 +513,7 @@ namespace Sig.App.Backend.Gql.Schema
         [RequirePermission(GlobalPermission.ManageTransactions)]
         [Description("All transactions")]
         public static async Task<TransactionLogsPagination<TransactionLogGraphType>> TransactionLogs(this GqlQuery _, [Inject] IMediator mediator, [Inject] AppDbContext db,
-            int page, int limit, Id projectId, DateTime startDate, DateTime endDate, Id[] organizations, Id[] subscriptions, Id[] markets, bool? withoutSubscription, Id[] categories, string[] transactionTypes, string[] giftCardTransactionTypes, Id[] cashRegisters, string searchText, string timeZoneId)
+            int page, int limit, Id projectId, DateTime startDate, DateTime endDate, Id[] organizations, Id[] subscriptions, Id[] markets, bool? withoutSubscription, Id[] categories, string[] transactionTypes, string[] giftCardTransactionTypes, Id[] marketGroups, string searchText, string timeZoneId)
         {
             var longProjectId = projectId.LongIdentifierForType<Project>();
             var isAnonymous = await db.Projects
@@ -530,7 +530,7 @@ namespace Sig.App.Backend.Gql.Schema
                 Organizations = organizations,
                 Subscriptions = subscriptions,
                 Markets = markets,
-                CashRegisters = cashRegisters,
+                MarketGroups = marketGroups,
                 WithoutSubscription = withoutSubscription,
                 Categories = categories,
                 TransactionTypes = transactionTypes,

--- a/Sig.App.Backend/Requests/Queries/Transactions/GenerateTransactionsReport.cs
+++ b/Sig.App.Backend/Requests/Queries/Transactions/GenerateTransactionsReport.cs
@@ -48,7 +48,7 @@ namespace Sig.App.Backend.Requests.Commands.Queries.Transactions
             public IEnumerable<Id> Organizations { get; set; }
             public IEnumerable<Id> Subscriptions { get; set; }
             public IEnumerable<Id> Markets { get; set; }
-            public IEnumerable<Id> CashRegisters { get; set; }
+            public IEnumerable<Id> MarketGroups { get; set; }
             public Maybe<bool> WithoutSubscription { get; set; }
             public IEnumerable<Id> Categories { get; set; }
             public IEnumerable<string> TransactionTypes { get; set; }

--- a/Sig.App.Backend/Requests/Queries/Transactions/ITransactionLogFilterCriteria.cs
+++ b/Sig.App.Backend/Requests/Queries/Transactions/ITransactionLogFilterCriteria.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using GraphQL.Conventions;
+using Sig.App.Backend.Gql.Schema.Types;
+
+namespace Sig.App.Backend.Requests.Queries.Transactions;
+
+public interface ITransactionLogFilterCriteria
+{
+    Id ProjectId { get; set; }
+    DateTime StartDate { get; set; }
+    DateTime EndDate { get; set; }
+    IEnumerable<Id> Organizations { get; }
+    IEnumerable<Id> Subscriptions { get; }
+    Maybe<bool> WithoutSubscription { get; }
+    IEnumerable<Id> Categories { get; }
+    IEnumerable<Id> Markets { get; }
+    IEnumerable<Id> MarketGroups { get; }
+    IEnumerable<string> TransactionTypes { get; }
+    IEnumerable<string> GiftCardTransactionTypes { get; }
+    Maybe<string> SearchText { get; }
+}

--- a/Sig.App.Backend/Requests/Queries/Transactions/SearchTransactionLogs.cs
+++ b/Sig.App.Backend/Requests/Queries/Transactions/SearchTransactionLogs.cs
@@ -7,14 +7,9 @@ using Sig.App.Backend.DbModel;
 using Sig.App.Backend.Utilities;
 using Sig.App.Backend.Utilities.Sorting;
 using GraphQL.Conventions;
-using Sig.App.Backend.Extensions;
-using Sig.App.Backend.DbModel.Entities.Projects;
 using System.Collections.Generic;
 using Sig.App.Backend.Gql.Schema.Types;
-using Sig.App.Backend.DbModel.Entities.Organizations;
-using Sig.App.Backend.DbModel.Entities.Subscriptions;
 using Microsoft.EntityFrameworkCore;
-using Sig.App.Backend.DbModel.Entities.Beneficiaries;
 using Sig.App.Backend.Services.Beneficiaries;
 using Sig.App.Backend.Services.Permission.Enums;
 using Sig.App.Backend.Services.Permission;
@@ -24,9 +19,7 @@ using Sig.App.Backend.DbModel.Entities;
 using Sig.App.Backend.Constants;
 using Sig.App.Backend.DbModel.Entities.TransactionLogs;
 using Sig.App.Backend.DbModel.Enums;
-using Sig.App.Backend.DbModel.Entities.Markets;
 using Sig.App.Backend.Gql.Bases;
-using Sig.App.Backend.DbModel.Entities.MarketGroups;
 
 namespace Sig.App.Backend.Requests.Queries.Transactions
 {
@@ -51,118 +44,29 @@ namespace Sig.App.Backend.Requests.Queries.Transactions
         {
             var currentUserCanSeeAllBeneficiaryInfo = await beneficiaryService.CurrentUserCanSeeAllBeneficiaryInfo();
             var globalPermissions = await permissionService.GetGlobalPermissions(ctx.CurrentUser);
-            var longProjectId = request.ProjectId.LongIdentifierForType<Project>();
-
-            var startDate = request.StartDate.ToUniversalTime();
-            var endDate = request.EndDate.ToUniversalTime();
-
-            IQueryable<TransactionLog> query = db.TransactionLogs.Include(x => x.TransactionLogProductGroups).Where(x =>
-                x.CreatedAtUtc > startDate && x.CreatedAtUtc < endDate && x.ProjectId == longProjectId)
+            var query = db.TransactionLogs
+                .Include(x => x.TransactionLogProductGroups)
                 .Where(x => x.Discriminator != TransactionLogDiscriminator.ExpireFundTransactionLog || (x.TotalAmount > 0));
 
-            if(!globalPermissions.Contains(GlobalPermission.ManageOrganizations))
+            var canManageOrganizations = globalPermissions.Contains(GlobalPermission.ManageOrganizations);
+            string organizationManagerClaimValue = null;
+
+            if (!canManageOrganizations)
             {
                 var user = await db.Users.Where(c => c.Id == ctx.CurrentUserId).FirstAsync(cancellationToken: cancellationToken);
-
                 var existingClaims = await userManager.GetClaimsAsync(user);
-                var existingOrganizationsClaims = existingClaims.Where(x => x.Type == AppClaimTypes.OrganizationManagerOf).Select(x => x.Value).FirstOrDefault();
-                query = query.Where(x => x.OrganizationId.ToString() == existingOrganizationsClaims);
-            }
-            else if (request.Organizations?.Any() ?? false)
-            {
-                var organizationsLongIdentifiers = request.Organizations.Select(x => x.LongIdentifierForType<Organization>());
-                query = query.Where(x => organizationsLongIdentifiers.Contains(x.OrganizationId ?? 0));
+                organizationManagerClaimValue = existingClaims.Where(x => x.Type == AppClaimTypes.OrganizationManagerOf).Select(x => x.Value).FirstOrDefault();
             }
 
-            if (request.Subscriptions?.Any() ?? false)
-            {
-                var withoutSubscription = request.WithoutSubscription?.Value ?? false;
-                var subscriptionLongIdentifiers = request.Subscriptions.Select(x => x.LongIdentifierForType<Subscription>());
-                query = query.Where(x => (withoutSubscription && !x.SubscriptionId.HasValue) || subscriptionLongIdentifiers.Contains(x.SubscriptionId.GetValueOrDefault()));
-            }
-            else if (request.WithoutSubscription.IsSet() && request.WithoutSubscription.Value)
-            {
-                query = query.Where(x => !x.SubscriptionId.HasValue);
-            }
-
-            if (request.Categories?.Any() ?? false)
-            {
-                var categoriesLongIdentifiers = request.Categories.Select(x => x.LongIdentifierForType<BeneficiaryType>());
-                query = query.Where(x => categoriesLongIdentifiers.Contains(x.BeneficiaryTypeId.GetValueOrDefault()));
-            }
-
-            if (request.Markets?.Any() ?? false)
-            {
-                var marketsLongIdentifiers = request.Markets.Select(x => x.LongIdentifierForType<Market>());
-                query = query.Where(x => marketsLongIdentifiers.Contains(x.MarketId.GetValueOrDefault()));
-            }
-
-            if (request.MarketGroups?.Any() ?? false)
-            {
-                var marketGroupsLongIdentifiers = request.MarketGroups.Select(x => x.LongIdentifierForType<MarketGroup>());
-                query = query.Where(x => marketGroupsLongIdentifiers.Contains(x.MarketGroupId.GetValueOrDefault()));
-            }
-
-            if (request.TransactionTypes?.Any() ?? false)
-            {
-                var transactionLogDiscriminators =
-                    request.TransactionTypes.Select(x => Enum.Parse(typeof(TransactionLogDiscriminator), x));
-                query = query.Where(x => transactionLogDiscriminators.Contains(x.Discriminator));
-            }
-
-            if (request.GiftCardTransactionTypes?.Any() ?? false)
-            {
-                var withGiftCard = request.GiftCardTransactionTypes.Where(x => x == "withGiftCard").Any();
-                var withoutGiftCard = request.GiftCardTransactionTypes.Where(x => x == "withoutGiftCard").Any();
-
-                if (withoutGiftCard && withGiftCard)
-                {
-                    // Nothing to do in the case it's with and without
-                }
-                else if (withGiftCard)
-                {
-                    // When the transaction is made without an subscriptionId, the transaction is for a gift-card
-                    query = query.Where(x => x.SubscriptionId == null);
-                }
-                else if (withoutGiftCard)
-                {
-                    // When the transaction is made with an subscriptionId, the transaction is not for a gift-card
-                    query = query.Where(x => x.SubscriptionId != null);
-                }
-            }
-
-            if (request.SearchText.IsSet() && !string.IsNullOrEmpty(request.SearchText.Value))
-            {
-                var searchText = request.SearchText.Value.Split(' ').AsEnumerable();
-                foreach (var text in searchText)
-                {
-                    if (currentUserCanSeeAllBeneficiaryInfo)
-                    {
-                        query = query.Where(x =>
-                            EF.Functions.Collate(x.BeneficiaryID1, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryID2, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryEmail, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryFirstname, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryLastname, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.CardNumber, SearchCollation.AccentInsensitive).Contains(text)
-                        );
-                    }
-                    else
-                    {
-                        query = query.Where(x =>
-                            EF.Functions.Collate(x.BeneficiaryID1, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryID2, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.CardNumber, SearchCollation.AccentInsensitive).Contains(text)
-                        );
-                    }
-                }
-            }
+            query = query
+                .FilterByOrganizationScope(canManageOrganizations, organizationManagerClaimValue, request.Organizations)
+                .FilterByCriteria(request, currentUserCanSeeAllBeneficiaryInfo);
 
             var sorted = Sort(query, TransactionLogSort.Default, SortOrder.Desc);
             return await TransactionLogsPagination.For(sorted, request.Page);
         }
 
-        public class Query : IRequest<TransactionLogsPagination<TransactionLog>>
+        public class Query : IRequest<TransactionLogsPagination<TransactionLog>>, ITransactionLogFilterCriteria
         {
             public Page Page { get; set; }
             public Id ProjectId { get; set; }

--- a/Sig.App.Backend/Requests/Queries/Transactions/SearchTransactionLogs.cs
+++ b/Sig.App.Backend/Requests/Queries/Transactions/SearchTransactionLogs.cs
@@ -26,7 +26,7 @@ using Sig.App.Backend.DbModel.Entities.TransactionLogs;
 using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.DbModel.Entities.Markets;
 using Sig.App.Backend.Gql.Bases;
-using Sig.App.Backend.DbModel.Entities.CashRegisters;
+using Sig.App.Backend.DbModel.Entities.MarketGroups;
 
 namespace Sig.App.Backend.Requests.Queries.Transactions
 {
@@ -97,10 +97,10 @@ namespace Sig.App.Backend.Requests.Queries.Transactions
                 query = query.Where(x => marketsLongIdentifiers.Contains(x.MarketId.GetValueOrDefault()));
             }
 
-            if (request.CashRegisters?.Any() ?? false)
+            if (request.MarketGroups?.Any() ?? false)
             {
-                var cashRegistersLongIdentifiers = request.CashRegisters.Select(x => x.LongIdentifierForType<CashRegister>());
-                query = query.Where(x => cashRegistersLongIdentifiers.Contains(x.CashRegisterId.GetValueOrDefault()));
+                var marketGroupsLongIdentifiers = request.MarketGroups.Select(x => x.LongIdentifierForType<MarketGroup>());
+                query = query.Where(x => marketGroupsLongIdentifiers.Contains(x.MarketGroupId.GetValueOrDefault()));
             }
 
             if (request.TransactionTypes?.Any() ?? false)
@@ -171,7 +171,7 @@ namespace Sig.App.Backend.Requests.Queries.Transactions
             public IEnumerable<Id> Organizations { get; set; }
             public IEnumerable<Id> Subscriptions { get; set; }
             public IEnumerable<Id> Markets { get; set; }
-            public IEnumerable<Id> CashRegisters { get; set; }
+            public IEnumerable<Id> MarketGroups { get; set; }
             public Maybe<bool> WithoutSubscription { get; set; }
             public IEnumerable<Id> Categories { get; set; }
             public IEnumerable<string> TransactionTypes { get; set; }

--- a/Sig.App.Backend/Requests/Queries/Transactions/TransactionLogQueryFilters.cs
+++ b/Sig.App.Backend/Requests/Queries/Transactions/TransactionLogQueryFilters.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Sig.App.Backend/Requests/Queries/Transactions/TransactionLogQueryFilters.cs
+++ b/Sig.App.Backend/Requests/Queries/Transactions/TransactionLogQueryFilters.cs
@@ -1,0 +1,138 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Conventions;
+using Microsoft.EntityFrameworkCore;
+using Sig.App.Backend.Constants;
+using Sig.App.Backend.DbModel.Entities.Beneficiaries;
+using Sig.App.Backend.DbModel.Entities.MarketGroups;
+using Sig.App.Backend.DbModel.Entities.Markets;
+using Sig.App.Backend.DbModel.Entities.Organizations;
+using Sig.App.Backend.DbModel.Entities.Projects;
+using Sig.App.Backend.DbModel.Entities.Subscriptions;
+using Sig.App.Backend.DbModel.Entities.TransactionLogs;
+using Sig.App.Backend.DbModel.Enums;
+using Sig.App.Backend.Extensions;
+
+namespace Sig.App.Backend.Requests.Queries.Transactions
+{
+    public static class TransactionLogQueryFilters
+    {
+        public static IQueryable<TransactionLog> FilterByOrganizationScope(
+            this IQueryable<TransactionLog> query,
+            bool canManageOrganizations,
+            string organizationManagerClaimValue,
+            IEnumerable<Id> selectedOrganizations)
+        {
+            if (!canManageOrganizations)
+            {
+                return query.Where(x => x.OrganizationId.ToString() == organizationManagerClaimValue);
+            }
+
+            var organizationIds = selectedOrganizations?.ToArray() ?? [];
+            if (organizationIds.Any())
+            {
+                var organizationsLongIdentifiers = organizationIds.Select(x => x.LongIdentifierForType<Organization>());
+                return query.Where(x => organizationsLongIdentifiers.Contains(x.OrganizationId ?? 0));
+            }
+
+            return query;
+        }
+
+        public static IQueryable<TransactionLog> FilterByCriteria(
+            this IQueryable<TransactionLog> query,
+            ITransactionLogFilterCriteria criteria,
+            bool currentUserCanSeeAllBeneficiaryInfo)
+        {
+            var longProjectId = criteria.ProjectId.LongIdentifierForType<Project>();
+            var startDate = criteria.StartDate.ToUniversalTime();
+            var endDate = criteria.EndDate.ToUniversalTime();
+            query = query.Where(x => x.CreatedAtUtc > startDate && x.CreatedAtUtc < endDate && x.ProjectId == longProjectId);
+
+            if (criteria.Subscriptions?.Any() ?? false)
+            {
+                var withoutSubscription = criteria.WithoutSubscription?.Value ?? false;
+                var subscriptionLongIdentifiers = criteria.Subscriptions.Select(x => x.LongIdentifierForType<Subscription>());
+                query = query.Where(x => (withoutSubscription && !x.SubscriptionId.HasValue) || subscriptionLongIdentifiers.Contains(x.SubscriptionId.GetValueOrDefault()));
+            }
+            else if (criteria.WithoutSubscription.IsSet() && criteria.WithoutSubscription.Value)
+            {
+                query = query.Where(x => !x.SubscriptionId.HasValue);
+            }
+
+            if (criteria.Categories?.Any() ?? false)
+            {
+                var categoriesLongIdentifiers = criteria.Categories.Select(x => x.LongIdentifierForType<BeneficiaryType>());
+                query = query.Where(x => categoriesLongIdentifiers.Contains(x.BeneficiaryTypeId.GetValueOrDefault()));
+            }
+
+            if (criteria.Markets?.Any() ?? false)
+            {
+                var marketsLongIdentifiers = criteria.Markets.Select(x => x.LongIdentifierForType<Market>());
+                query = query.Where(x => marketsLongIdentifiers.Contains(x.MarketId.GetValueOrDefault()));
+            }
+
+            if (criteria.MarketGroups?.Any() ?? false)
+            {
+                var marketGroupsLongIdentifiers = criteria.MarketGroups.Select(x => x.LongIdentifierForType<MarketGroup>());
+                query = query.Where(x => marketGroupsLongIdentifiers.Contains(x.MarketGroupId.GetValueOrDefault()));
+            }
+
+            if (criteria.TransactionTypes?.Any() ?? false)
+            {
+                var transactionLogDiscriminators =
+                    criteria.TransactionTypes.Select(x => Enum.Parse(typeof(TransactionLogDiscriminator), x));
+                query = query.Where(x => transactionLogDiscriminators.Contains(x.Discriminator));
+            }
+
+            if (criteria.GiftCardTransactionTypes?.Any() ?? false)
+            {
+                var withGiftCard = criteria.GiftCardTransactionTypes.Any(x => x == "withGiftCard");
+                var withoutGiftCard = criteria.GiftCardTransactionTypes.Any(x => x == "withoutGiftCard");
+
+                if (withoutGiftCard && withGiftCard)
+                {
+                    // Nothing to do in the case it's with and without
+                }
+                else if (withGiftCard)
+                {
+                    query = query.Where(x => x.SubscriptionId == null);
+                }
+                else if (withoutGiftCard)
+                {
+                    query = query.Where(x => x.SubscriptionId != null);
+                }
+            }
+
+            if (criteria.SearchText.IsSet() && !string.IsNullOrEmpty(criteria.SearchText.Value))
+            {
+                var searchText = criteria.SearchText.Value.Split(' ').AsEnumerable();
+                foreach (var text in searchText)
+                {
+                    if (currentUserCanSeeAllBeneficiaryInfo)
+                    {
+                        query = query.Where(x =>
+                            EF.Functions.Collate(x.BeneficiaryID1, SearchCollation.AccentInsensitive).Contains(text) ||
+                            EF.Functions.Collate(x.BeneficiaryID2, SearchCollation.AccentInsensitive).Contains(text) ||
+                            EF.Functions.Collate(x.BeneficiaryEmail, SearchCollation.AccentInsensitive).Contains(text) ||
+                            EF.Functions.Collate(x.BeneficiaryFirstname, SearchCollation.AccentInsensitive).Contains(text) ||
+                            EF.Functions.Collate(x.BeneficiaryLastname, SearchCollation.AccentInsensitive).Contains(text) ||
+                            EF.Functions.Collate(x.CardNumber, SearchCollation.AccentInsensitive).Contains(text)
+                        );
+                    }
+                    else
+                    {
+                        query = query.Where(x =>
+                            EF.Functions.Collate(x.BeneficiaryID1, SearchCollation.AccentInsensitive).Contains(text) ||
+                            EF.Functions.Collate(x.BeneficiaryID2, SearchCollation.AccentInsensitive).Contains(text) ||
+                            EF.Functions.Collate(x.CardNumber, SearchCollation.AccentInsensitive).Contains(text)
+                        );
+                    }
+                }
+            }
+
+            return query;
+        }
+    }
+}

--- a/Sig.App.Backend/Services/Reports/IReportService.cs
+++ b/Sig.App.Backend/Services/Reports/IReportService.cs
@@ -1,8 +1,7 @@
 ﻿using GraphQL.Conventions;
 using Sig.App.Backend.Gql.Schema.Enums;
-using Sig.App.Backend.Gql.Schema.Types;
+using Sig.App.Backend.Requests.Queries.Transactions;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -14,22 +13,10 @@ namespace Sig.App.Backend.Services.Reports
         Task<Stream> GenerateTransactionReportForMarket(IReportForMarketInput request);
     }
 
-    public interface IReportInput
+    public interface IReportInput : ITransactionLogFilterCriteria
     {
-        public Id ProjectId { get; set; }
-        public DateTime StartDate { get; set; }
-        public DateTime EndDate { get; set; }
-        public IEnumerable<Id> Organizations { get; set; }
-        public IEnumerable<Id> Subscriptions { get; set; }
-        public Maybe<bool> WithoutSubscription { get; set; }
-        public IEnumerable<Id> Categories { get; set; }
-        public IEnumerable<Id> Markets { get; set; }
-        public IEnumerable<Id> MarketGroups { get; set; }
-        public IEnumerable<string> TransactionTypes { get; set; }
-        public IEnumerable<string> GiftCardTransactionTypes { get; set; }
-        public Maybe<string> SearchText { get; set; }
-        public string TimeZoneId { get; set; }
-        public Language Language { get; set; }
+        string TimeZoneId { get; set; }
+        Language Language { get; set; }
     }
 
     public interface IReportForMarketInput

--- a/Sig.App.Backend/Services/Reports/IReportService.cs
+++ b/Sig.App.Backend/Services/Reports/IReportService.cs
@@ -24,7 +24,7 @@ namespace Sig.App.Backend.Services.Reports
         public Maybe<bool> WithoutSubscription { get; set; }
         public IEnumerable<Id> Categories { get; set; }
         public IEnumerable<Id> Markets { get; set; }
-        public IEnumerable<Id> CashRegisters { get; set; }
+        public IEnumerable<Id> MarketGroups { get; set; }
         public IEnumerable<string> TransactionTypes { get; set; }
         public IEnumerable<string> GiftCardTransactionTypes { get; set; }
         public Maybe<string> SearchText { get; set; }

--- a/Sig.App.Backend/Services/Reports/ReportService.cs
+++ b/Sig.App.Backend/Services/Reports/ReportService.cs
@@ -11,17 +11,14 @@ using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.Gql.Interfaces;
 using Sig.App.Backend.Extensions;
 using Sig.App.Backend.DbModel.Entities.Projects;
-using Sig.App.Backend.DbModel.Entities.Beneficiaries;
-using Sig.App.Backend.DbModel.Entities.Subscriptions;
-using Sig.App.Backend.DbModel.Entities.Organizations;
+using Sig.App.Backend.DbModel.Entities.Markets;
 using Sig.App.Backend.DbModel.Entities;
 using Sig.App.Backend.Services.Permission;
 using Microsoft.AspNetCore.Identity;
 using Sig.App.Backend.DbModel.Entities.TransactionLogs;
 using Sig.App.Backend.Services.Permission.Enums;
 using Sig.App.Backend.Gql.Schema.Enums;
-using Sig.App.Backend.DbModel.Entities.Markets;
-using Sig.App.Backend.DbModel.Entities.MarketGroups;
+using Sig.App.Backend.Requests.Queries.Transactions;
 
 namespace Sig.App.Backend.Services.Reports
 {
@@ -93,109 +90,21 @@ namespace Sig.App.Backend.Services.Reports
                 .Where(p => p.Id == longProjectId)
                 .Select(p => p.BeneficiariesAreAnonymous)
                 .FirstOrDefaultAsync();
-            var startDate = request.StartDate.ToUniversalTime();
-            var endDate = request.EndDate.ToUniversalTime();
+            IQueryable<TransactionLog> query = db.TransactionLogs.Include(x => x.TransactionLogProductGroups);
 
-            IQueryable<TransactionLog> query = db.TransactionLogs.Include(x => x.TransactionLogProductGroups).Where(x =>
-                x.CreatedAtUtc > startDate && x.CreatedAtUtc < endDate && x.ProjectId == longProjectId);
+            var canManageOrganizations = globalPermissions.Contains(GlobalPermission.ManageOrganizations);
+            string organizationManagerClaimValue = null;
 
-            if (!globalPermissions.Contains(GlobalPermission.ManageOrganizations))
+            if (!canManageOrganizations)
             {
-                var user = await db.Users
-                .Where(c => c.Id == ctx.CurrentUserId)
-                .FirstAsync();
-
+                var user = await db.Users.Where(c => c.Id == ctx.CurrentUserId).FirstAsync();
                 var existingClaims = await userManager.GetClaimsAsync(user);
-                var existingOrganizationsClaims = existingClaims.Where(x => x.Type == AppClaimTypes.OrganizationManagerOf).Select(x => x.Value).FirstOrDefault();
-                query = query.Where(x => x.OrganizationId.ToString() == existingOrganizationsClaims);
-            }
-            else if(request.Organizations?.Any() ?? false)
-            {
-                var organizationsLongIdentifiers = request.Organizations.Select(x => x.LongIdentifierForType<Organization>());
-                query = query.Where(x => organizationsLongIdentifiers.Contains(x.OrganizationId.GetValueOrDefault()));
+                organizationManagerClaimValue = existingClaims.Where(x => x.Type == AppClaimTypes.OrganizationManagerOf).Select(x => x.Value).FirstOrDefault();
             }
 
-            if (request.Subscriptions?.Any() ?? false)
-            {
-                var withoutSubscription = request.WithoutSubscription?.Value ?? false;
-                var subscriptionLongIdentifiers = request.Subscriptions.Select(x => x.LongIdentifierForType<Subscription>());
-                query = query.Where(x => (withoutSubscription && !x.SubscriptionId.HasValue) || subscriptionLongIdentifiers.Contains(x.SubscriptionId.GetValueOrDefault()));
-            }
-            else if (request.WithoutSubscription.IsSet() && request.WithoutSubscription.Value)
-            {
-                query = query.Where(x => !x.SubscriptionId.HasValue);
-            }
-
-            if (request.Categories?.Any() ?? false)
-            {
-                var categoriesLongIdentifiers = request.Categories.Select(x => x.LongIdentifierForType<BeneficiaryType>());
-                query = query.Where(x => categoriesLongIdentifiers.Contains(x.BeneficiaryTypeId.GetValueOrDefault()));
-            }
-
-            if (request.Markets?.Any() ?? false)
-            {
-                var marketsLongIdentifiers = request.Markets.Select(x => x.LongIdentifierForType<Market>());
-                query = query.Where(x => marketsLongIdentifiers.Contains(x.MarketId.GetValueOrDefault()));
-            }
-
-            if (request.MarketGroups?.Any() ?? false)
-            {
-                var marketGroupsLongIdentifiers = request.MarketGroups.Select(x => x.LongIdentifierForType<MarketGroup>());
-                query = query.Where(x => marketGroupsLongIdentifiers.Contains(x.MarketGroupId.GetValueOrDefault()));
-            }
-
-            if (request.TransactionTypes?.Any() ?? false)
-            {
-                var transactionLogDiscriminators =
-                    request.TransactionTypes.Select(x => Enum.Parse(typeof(TransactionLogDiscriminator), x));
-                query = query.Where(x => transactionLogDiscriminators.Contains(x.Discriminator));
-            }
-
-            if (request.GiftCardTransactionTypes?.Any() ?? false)
-            {
-                var withGiftCard = request.GiftCardTransactionTypes.Where(x => x == "withGiftCard").Any();
-                var withoutGiftCard = request.GiftCardTransactionTypes.Where(x => x == "withoutGiftCard").Any();
-
-                if (withoutGiftCard && withGiftCard)
-                {
-                    // Nothing to do in the case it's with and without
-                }
-                else if (withGiftCard)
-                {
-                    // When the transaction is made without an organizationId, the transaction is for a gift-card
-                    query = query.Where(x => x.OrganizationId == null);
-                }
-                else if (withoutGiftCard)
-                {
-                    // When the transaction is made with an organizationId, the transaction is not for a gift-card
-                    query = query.Where(x => x.OrganizationId != null);
-                }
-            }
-
-            if (request.SearchText.IsSet() && !string.IsNullOrEmpty(request.SearchText.Value))
-            {
-                var searchText = request.SearchText.Value.Split(' ').AsEnumerable();
-                foreach (var text in searchText)
-                {
-                    if (currentUserCanSeeAllBeneficiaryInfo)
-                    {
-                        query = query.Where(x =>
-                            EF.Functions.Collate(x.BeneficiaryID1, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryID2, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryEmail, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryFirstname, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryLastname, SearchCollation.AccentInsensitive).Contains(text)
-                        );
-                    }
-                    else
-                    {
-                        query = query.Where(x =>
-                            EF.Functions.Collate(x.BeneficiaryID1, SearchCollation.AccentInsensitive).Contains(text) ||
-                            EF.Functions.Collate(x.BeneficiaryID2, SearchCollation.AccentInsensitive).Contains(text)
-                        );
-                    }
-                }
-            }
+            query = query
+                .FilterByOrganizationScope(canManageOrganizations, organizationManagerClaimValue, request.Organizations)
+                .FilterByCriteria(request, currentUserCanSeeAllBeneficiaryInfo);
 
             var transactions = await query.OrderByDescending(x => x.CreatedAtUtc).ToListAsync();
             var productGroupDictionary = transactions

--- a/Sig.App.Backend/Services/Reports/ReportService.cs
+++ b/Sig.App.Backend/Services/Reports/ReportService.cs
@@ -21,7 +21,7 @@ using Sig.App.Backend.DbModel.Entities.TransactionLogs;
 using Sig.App.Backend.Services.Permission.Enums;
 using Sig.App.Backend.Gql.Schema.Enums;
 using Sig.App.Backend.DbModel.Entities.Markets;
-using Sig.App.Backend.DbModel.Entities.CashRegisters;
+using Sig.App.Backend.DbModel.Entities.MarketGroups;
 
 namespace Sig.App.Backend.Services.Reports
 {
@@ -138,10 +138,10 @@ namespace Sig.App.Backend.Services.Reports
                 query = query.Where(x => marketsLongIdentifiers.Contains(x.MarketId.GetValueOrDefault()));
             }
 
-            if (request.CashRegisters?.Any() ?? false)
+            if (request.MarketGroups?.Any() ?? false)
             {
-                var cashRegistersLongIdentifiers = request.CashRegisters.Select(x => x.LongIdentifierForType<CashRegister>());
-                query = query.Where(x => cashRegistersLongIdentifiers.Contains(x.CashRegisterId.GetValueOrDefault()));
+                var marketGroupsLongIdentifiers = request.MarketGroups.Select(x => x.LongIdentifierForType<MarketGroup>());
+                query = query.Where(x => marketGroupsLongIdentifiers.Contains(x.MarketGroupId.GetValueOrDefault()));
             }
 
             if (request.TransactionTypes?.Any() ?? false)

--- a/Sig.App.Frontend/src/components/transaction/program-transaction-filters.vue
+++ b/Sig.App.Frontend/src/components/transaction/program-transaction-filters.vue
@@ -23,7 +23,7 @@
     "transaction-log-type-refund-budget-allowance-from-removed-beneficiary-from-subscription": "Budget envelope refund from participant removed from subscription",
     "transaction-log-type-refund-payment": "Purchase refund",
     "market": "Merchants",
-    "cash-register": "Cash Registers",
+    "market-groups": "Merchant Groups",
     "gift-card-transaction-types": "Gift Card Transaction Types",
     "with-gift-card": "With Gift Card",
     "without-gift-card": "Without Gift Card"
@@ -51,7 +51,7 @@
     "transaction-log-type-refund-budget-allowance-from-removed-beneficiary-from-subscription": "Enveloppe remboursée après avoir retiré un·e participant·e d'un abonnement",
     "transaction-log-type-refund-payment": "Remboursement d'un achat",
     "market": "Commerces",
-    "cash-register": "Caisses",
+    "market-groups": "Groupes de commerces",
     "gift-card-transaction-types": "Carte-cadeaux",
     "with-gift-card": "Avec carte-cadeau",
     "without-gift-card": "Sans carte-cadeau"
@@ -136,15 +136,15 @@
             :options="availableMarkets"
             @input="onMarketsChecked" />
         </UiFilterSelect>
-        <UiFilterSelect :label="t('cash-register')" :active-filters-count="cashRegisterActiveFiltersCount">
+        <UiFilterSelect :label="t('market-groups')" :active-filters-count="marketGroupActiveFiltersCount">
           <PfFormInputCheckboxGroup
-            v-if="availableCashRegister.length > 0"
-            id="cashRegisters"
+            v-if="availableMarketGroups.length > 0"
+            id="marketGroups"
             class="mt-3"
             is-filter
-            :value="selectedCashRegisters"
-            :options="availableCashRegister"
-            @input="onCashRegistersChecked" />
+            :value="selectedMarketGroups"
+            :options="availableMarketGroups"
+            @input="onMarketGroupsChecked" />
         </UiFilterSelect>
         <UiFilterSelect :label="t('transaction-log-types')" :active-filters-count="transactionTypeActiveFiltersCount">
           <PfFormInputCheckboxGroup
@@ -196,8 +196,8 @@ const emit = defineEmits([
   "dateToUpdated",
   "marketsChecked",
   "marketsUnchecked",
-  "cashRegistersChecked",
-  "cashRegistersUnchecked",
+  "marketGroupsChecked",
+  "marketGroupsUnchecked",
   "giftCardTransactionTypesChecked",
   "giftCardTransactionTypesUnchecked"
 ]);
@@ -245,7 +245,7 @@ const props = defineProps({
       return [];
     }
   },
-  availableCashRegister: {
+  availableMarketGroups: {
     type: Array,
     default() {
       return [];
@@ -257,7 +257,7 @@ const props = defineProps({
       return [];
     }
   },
-  selectedCashRegisters: {
+  selectedMarketGroups: {
     type: Array,
     default() {
       return [];
@@ -276,10 +276,6 @@ const props = defineProps({
     }
   },
   withoutSubscriptionId: {
-    type: String,
-    default: ""
-  },
-  withCashRegisterId: {
     type: String,
     default: ""
   },
@@ -347,7 +343,7 @@ const hasActiveFilters = computed(() => {
     props.selectedBeneficiaryTypes?.length > 0 ||
     props.selectedSubscriptions?.length > 0 ||
     props.selectedTransactionTypes?.length > 0 ||
-    props.selectedCashRegisters?.length > 0 ||
+    props.selectedMarketGroups?.length > 0 ||
     props.selectedMarkets?.length > 0 ||
     !!props.searchFilter
   );
@@ -358,7 +354,7 @@ const activeFiltersCount = computed(() => {
   const selectedBeneficiariesCount = props.selectedBeneficiaryTypes?.length ?? 0;
   const selectedSubscritionsCount = props.selectedSubscriptions?.length ?? 0;
   const selectedTransactionTypesCount = props.selectedTransactionTypes?.length ?? 0;
-  const selectedCashRegistersCount = props.selectedCashRegisters?.length ?? 0;
+  const selectedMarketGroupsCount = props.selectedMarketGroups?.length ?? 0;
   const selectedMarketsCount = props.selectedMarkets?.length ?? 0;
 
   return (
@@ -366,7 +362,7 @@ const activeFiltersCount = computed(() => {
     selectedBeneficiariesCount +
     selectedSubscritionsCount +
     selectedTransactionTypesCount +
-    selectedCashRegistersCount +
+    selectedMarketGroupsCount +
     selectedMarketsCount
   );
 });
@@ -387,8 +383,8 @@ const marketActiveFiltersCount = computed(() => {
   return props.selectedMarkets?.length ?? 0;
 });
 
-const cashRegisterActiveFiltersCount = computed(() => {
-  return props.selectedCashRegisters?.length ?? 0;
+const marketGroupActiveFiltersCount = computed(() => {
+  return props.selectedMarketGroups?.length ?? 0;
 });
 
 const transactionTypeActiveFiltersCount = computed(() => {
@@ -430,9 +426,9 @@ const availableMarkets = computed(() => {
   return props.availableMarkets.map((x) => ({ value: x.id, label: x.name })).sort((a, b) => a.label.localeCompare(b.label));
 });
 
-const availableCashRegister = computed(() => {
-  if (!props.availableCashRegister || props.availableCashRegister?.length <= 0) return [];
-  return props.availableCashRegister.map((x) => ({ value: x.id, label: x.name }));
+const availableMarketGroups = computed(() => {
+  if (!props.availableMarketGroups || props.availableMarketGroups?.length <= 0) return [];
+  return props.availableMarketGroups.map((x) => ({ value: x.id, label: x.name })).sort((a, b) => a.label.localeCompare(b.label));
 });
 
 const availableTransactionTypes = computed(() => {
@@ -492,11 +488,11 @@ function onMarketsChecked(input) {
   }
 }
 
-function onCashRegistersChecked(input) {
+function onMarketGroupsChecked(input) {
   if (input.isChecked) {
-    emit("cashRegistersChecked", input.value);
+    emit("marketGroupsChecked", input.value);
   } else {
-    emit("cashRegistersUnchecked", input.value);
+    emit("marketGroupsUnchecked", input.value);
   }
 }
 

--- a/Sig.App.Frontend/src/views/transaction/ListTransactions.vue
+++ b/Sig.App.Frontend/src/views/transaction/ListTransactions.vue
@@ -28,12 +28,12 @@
                 :available-beneficiary-types="availableBeneficiaryTypes"
                 :available-subscriptions="availableSubscriptions"
                 :available-markets="availableMarkets"
-                :available-cash-register="availableCashRegisters"
+                :available-market-groups="availableMarketGroups"
                 :selected-organizations="organizations"
                 :selected-beneficiary-types="beneficiaryTypes"
                 :selected-subscriptions="subscriptions"
                 :selected-markets="markets"
-                :selected-cash-registers="cashRegisters"
+                :selected-market-groups="marketGroups"
                 :selected-transaction-types="transactionTypes"
                 :selected-gift-card-transaction-types="giftCardTransactionTypes"
                 :without-subscription-id="WITHOUT_SUBSCRIPTION"
@@ -51,8 +51,8 @@
                 @subscriptionsChecked="onSubscriptionsChecked"
                 @marketsUnchecked="onMarketsUnchecked"
                 @marketsChecked="onMarketsChecked"
-                @cashRegistersUnchecked="onCashRegistersUnchecked"
-                @cashRegistersChecked="onCashRegistersChecked"
+                @marketGroupsUnchecked="onMarketGroupsUnchecked"
+                @marketGroupsChecked="onMarketGroupsChecked"
                 @transactionTypesChecked="onTransactionTypesChecked"
                 @transactionTypesUnchecked="onTransactionTypesUnchecked"
                 @dateFromUpdated="onDateFromUpdated"
@@ -145,7 +145,7 @@ const organizations = ref([]);
 const beneficiaryTypes = ref([]);
 const subscriptions = ref([]);
 const markets = ref([]);
-const cashRegisters = ref([]);
+const marketGroups = ref([]);
 const transactionTypes = ref([]);
 const giftCardTransactionTypes = ref([]);
 const searchInput = ref("");
@@ -167,8 +167,8 @@ if (route.query.subscriptions) {
 if (route.query.markets) {
   markets.value = route.query.markets.split(",");
 }
-if (route.query.cashRegisters) {
-  cashRegisters.value = route.query.cashRegisters.split(",");
+if (route.query.marketGroups) {
+  marketGroups.value = route.query.marketGroups.split(",");
 }
 if (route.query.transactionTypes) {
   transactionTypes.value = route.query.transactionTypes.split(",");
@@ -211,10 +211,6 @@ const { result: resultProjects, loading: loadingProjects } = useQuery(
         marketGroups {
           id
           name
-          cashRegisters {
-            id
-            name
-          }
         }
         beneficiaryTypes {
           id
@@ -268,10 +264,6 @@ const { result: resultOrganizations } = useQuery(
           marketGroups {
             id
             name
-            cashRegisters {
-              id
-              name
-            }
           }
           administrationSubscriptionsOffPlatform
         }
@@ -317,7 +309,7 @@ const {
       $categories: [ID!]
       $subscriptions: [ID!]
       $markets: [ID!]
-      $cashRegisters: [ID!]
+      $marketGroups: [ID!]
       $withoutSubscription: Boolean
       $transactionTypes: [String]
       $giftCardTransactionTypes: [String]
@@ -333,7 +325,7 @@ const {
         categories: $categories
         subscriptions: $subscriptions
         markets: $markets
-        cashRegisters: $cashRegisters
+        marketGroups: $marketGroups
         withoutSubscription: $withoutSubscription
         transactionTypes: $transactionTypes
         giftCardTransactionTypes: $giftCardTransactionTypes
@@ -411,7 +403,7 @@ const {
       organizations: organizations.value,
       subscriptions: subscriptions.value.length > 0 ? subscriptions.value.filter((x) => x !== WITHOUT_SUBSCRIPTION) : null,
       markets: markets.value,
-      cashRegisters: cashRegisters.value,
+      marketGroups: marketGroups.value,
       withoutSubscription: subscriptions.value.indexOf(WITHOUT_SUBSCRIPTION) !== -1 ? true : null,
       categories: beneficiaryTypes.value,
       transactionTypes: transactionTypes.value,
@@ -433,7 +425,7 @@ const filteredQuery = computed(() => {
     organizations: organizations.value.length > 0 ? organizations.value.toString() : undefined,
     subscriptions: subscriptions.value.length > 0 ? subscriptions.value.toString() : undefined,
     markets: markets.value.length > 0 ? markets.value.toString() : undefined,
-    cashRegisters: cashRegisters.value.length > 0 ? cashRegisters.value.toString() : undefined,
+    marketGroups: marketGroups.value.length > 0 ? marketGroups.value.toString() : undefined,
     beneficiaryTypes: beneficiaryTypes.value.length > 0 ? beneficiaryTypes.value.toString() : undefined,
     transactionTypes: transactionTypes.value.length > 0 ? transactionTypes.value.toString() : undefined,
     giftCardTransactionTypes: giftCardTransactionTypes.value.length > 0 ? giftCardTransactionTypes.value.toString() : undefined,
@@ -467,9 +459,8 @@ let availableMarkets = computed(() => {
   return project.value?.markets;
 });
 
-let availableCashRegisters = computed(() => {
-  var cashRegister = project.value?.marketGroups.flatMap((x) => x.cashRegisters) ?? [];
-  return cashRegister.filter((x, index) => cashRegister.findIndex((y) => y.id === x.id) === index);
+let availableMarketGroups = computed(() => {
+  return project.value?.marketGroups ?? [];
 });
 
 let administrationSubscriptionsOffPlatform = computed(() => {
@@ -516,14 +507,14 @@ function onMarketsUnchecked(value) {
   markets.value = markets.value.filter((x) => x !== value);
 }
 
-function onCashRegistersChecked(value) {
+function onMarketGroupsChecked(value) {
   page.value = 1;
-  cashRegisters.value.push(value);
+  marketGroups.value.push(value);
 }
 
-function onCashRegistersUnchecked(value) {
+function onMarketGroupsUnchecked(value) {
   page.value = 1;
-  cashRegisters.value = cashRegisters.value.filter((x) => x !== value);
+  marketGroups.value = marketGroups.value.filter((x) => x !== value);
 }
 
 function onTransactionTypesChecked(value) {
@@ -565,7 +556,7 @@ function onResetFilters() {
   organizations.value = [];
   subscriptions.value = [];
   markets.value = [];
-  cashRegisters.value = [];
+  marketGroups.value = [];
   beneficiaryTypes.value = [];
   transactionTypes.value = [];
   giftCardTransactionTypes.value = [];
@@ -601,7 +592,7 @@ async function onExportReport() {
     organizations: organizations.value,
     subscriptions: subscriptions.value.length > 0 ? subscriptions.value.filter((x) => x !== WITHOUT_SUBSCRIPTION) : null,
     markets: markets.value,
-    cashRegisters: cashRegisters.value,
+    marketGroups: marketGroups.value,
     withoutSubscription: subscriptions.value.indexOf(WITHOUT_SUBSCRIPTION) !== -1 ? true : null,
     categories: beneficiaryTypes.value,
     transactionTypes: transactionTypes.value,
@@ -621,7 +612,7 @@ async function onExportReport() {
         $categories: [ID!]
         $subscriptions: [ID!]
         $markets: [ID!]
-        $cashRegisters: [ID!]
+        $marketGroups: [ID!]
         $withoutSubscription: Boolean
         $transactionTypes: [String]
         $giftCardTransactionTypes: [String]
@@ -637,7 +628,7 @@ async function onExportReport() {
           categories: $categories
           subscriptions: $subscriptions
           markets: $markets
-          cashRegisters: $cashRegisters
+          marketGroups: $marketGroups
           withoutSubscription: $withoutSubscription
           transactionTypes: $transactionTypes
           giftCardTransactionTypes: $giftCardTransactionTypes


### PR DESCRIPTION
# [JIRA - Remplacer le filtre par Caisse sur la page Transactions par un filtre par Groupe de commerces](https://sigmund-ca.atlassian.net/browse/CRCL-2522)

La liste de caisses sur l'historique des transactions programme (`/transactions`) est trop longue pour être utile comme filtre. Cette PR remplace le filtre **Caisses** par **Groupes de commerces**, en s'appuyant sur `TransactionLog.MarketGroupId` déjà présent en base.

## Changements

### Frontend
- `program-transaction-filters.vue` : filtre « Groupes de commerces » (checkbox, tri alphabétique) à la place de « Caisses »
- `ListTransactions.vue` : état, requêtes GraphQL, paramètre URL `?marketGroups=` et export alignés

### Backend
- GraphQL `transactionLogs` et `generateTransactionsReport` : argument `cashRegisters` remplacé par `marketGroups`
- Filtrage sur `TransactionLog.MarketGroupId` dans la recherche et l'export Excel
- Refactor: `ITransactionLogFilterCriteria` + extensions `FilterByOrganizationScope` / `FilterByCriteria` (`TransactionLogQueryFilters.cs`) partagées entre `SearchTransactionLogs` et `ReportService`
- L'export suit désormais la même logique que la liste (filtre carte-cadeau via `SubscriptionId`, recherche texte incluant `CardNumber`) @joc-sigmund point particulier à porter attention lors du review (la logique dans le rapport me semblait être légèrement désuète vis-à-vis SearchTransactionLogs).

### Hors scope (inchangé)
- Pages commerçant `/market-transactions` et `/market-group-transactions` : filtre Caisses conservé

**Note :** les anciens liens avec `?cashRegisters=...` ne fonctionnent plus ; le paramètre est `?marketGroups=`.

## Test plan
- [ ] Ouvrir `/transactions` : le filtre s'intitule « Groupes de commerces », au lieu de « Caisses »
- [ ] Cocher un ou plusieurs groupes : la liste se rafraîchit avec des résultats cohérents
- [ ] Combiner avec le filtre Commerces : intersection des deux filtres
- [ ] Réinitialiser les filtres : le filtre groupe est vidé
- [ ] Exporter un rapport avec filtre groupe actif : le fichier contient les mêmes transactions que l'écran
- [ ] Confirmer que `/market-transactions` et `/market-group-transactions` conservent le filtre Caisses
