### PR TITLE
Add current month button to reconciliation report (CRCL-2525)

### DIFF
--- a/Sig.App.Frontend/src/components/report/report-filters.vue
+++ b/Sig.App.Frontend/src/components/report/report-filters.vue
@@ -62,7 +62,7 @@
           <UiDatePicker
             id="dateTo"
             :value="props.modelValue.dateTo"
-            :min-date="props.dateFrom"
+            :min-date="props.modelValue.dateFrom"
             class="sm:col-span-6"
             :label="t('date-end-label')"
             has-hidden-label

--- a/Sig.App.Frontend/src/components/report/report-filters.vue
+++ b/Sig.App.Frontend/src/components/report/report-filters.vue
@@ -10,6 +10,7 @@
     "last-year": "Last year",
     "current-year": "Current year",
     "last-month": "Last month",
+    "current-month": "Current month",
     "all-time": "All time",
     "reset-filters": "Reset",
     "market-groups": "Merchant Groups"
@@ -24,6 +25,7 @@
     "last-year": "Année dernière",
     "current-year": "Année en cours",
     "last-month": "Mois dernier",
+    "current-month": "Mois en cours",
     "all-time": "Toutes les dates",
     "reset-filters": "Réinitialiser",
     "market-groups": "Groupes de commerces"
@@ -71,6 +73,7 @@
         <PfButtonAction btn-style="outline" :label="t('last-year')" @click="setDates('last-year')" />
         <PfButtonAction btn-style="outline" :label="t('current-year')" @click="setDates('current-year')" />
         <PfButtonAction btn-style="outline" :label="t('last-month')" @click="setDates('last-month')" />
+        <PfButtonAction btn-style="outline" :label="t('current-month')" @click="setDates('current-month')" />
         <PfButtonAction btn-style="outline" :label="t('all-time')" @click="setDates('all-time')" />
         <UiFilterSelect
           v-if="availableOrganizations.length > 0"
@@ -238,6 +241,13 @@ function setDates(type) {
     case "last-month": {
       const newDateFrom = new Date(new Date().getFullYear(), new Date().getMonth() - 1, 1);
       const newDateTo = new Date(new Date().getFullYear(), new Date().getMonth(), 0);
+      emit("update:modelValue", { ...props.modelValue, dateFrom: newDateFrom, dateTo: newDateTo });
+      break;
+    }
+    case "current-month": {
+      const now = new Date();
+      const newDateFrom = new Date(now.getFullYear(), now.getMonth(), 1);
+      const newDateTo = new Date(now.getFullYear(), now.getMonth() + 1, 0);
       emit("update:modelValue", { ...props.modelValue, dateFrom: newDateFrom, dateTo: newDateTo });
       break;
     }

--- a/Sig.App.Frontend/src/views/report/BudgetAllowanceReport.vue
+++ b/Sig.App.Frontend/src/views/report/BudgetAllowanceReport.vue
@@ -81,6 +81,7 @@ const searchInput = ref({
 });
 
 const page = ref(1);
+const hasAppliedDefaultDates = ref(Boolean(route.query.dateFrom || route.query.dateTo));
 const availableSubscriptions = ref([]);
 const availableOrganizations = ref([]);
 
@@ -181,8 +182,11 @@ const { result: resultProjects, loading: loadingProjects } = useQuery(
 );
 
 const project = useResult(resultProjects, null, (data) => {
-  if (!route.query.dateFrom && !route.query.dateTo) {
-    setDateFrom(data.projects[0].reconciliationReportDate);
+  if (!hasAppliedDefaultDates.value) {
+    if (!route.query.dateFrom && !route.query.dateTo) {
+      setDateFrom(data.projects[0].reconciliationReportDate);
+    }
+    hasAppliedDefaultDates.value = true;
   }
 
   updateUrl();

--- a/Sig.App.Frontend/src/views/report/ReconciliationReport.vue
+++ b/Sig.App.Frontend/src/views/report/ReconciliationReport.vue
@@ -79,6 +79,7 @@ const searchInput = ref({
   selectedMarketGroups: []
 });
 const page = ref(1);
+const hasAppliedDefaultDates = ref(Boolean(route.query.dateFrom || route.query.dateTo));
 
 if (route.query.dateFrom) {
   searchInput.value.dateFrom = new Date(route.query.dateFrom);
@@ -174,8 +175,11 @@ const { result: resultProjects, loading: loadingProjects } = useQuery(
 );
 
 const project = useResult(resultProjects, null, (data) => {
-  if (!route.query.dateFrom && !route.query.dateTo) {
-    setDateFrom(data.projects[0].reconciliationReportDate);
+  if (!hasAppliedDefaultDates.value) {
+    if (!route.query.dateFrom && !route.query.dateTo) {
+      setDateFrom(data.projects[0].reconciliationReportDate);
+    }
+    hasAppliedDefaultDates.value = true;
   }
 
   return data.projects[0];
@@ -230,8 +234,11 @@ const { result: resultMarketGroups, loading: loadingMarketGroups } = useQuery(
 );
 
 const marketGroup = useResult(resultMarketGroups, null, (data) => {
-  if (!route.query.dateFrom && !route.query.dateTo) {
-    setDateFrom(data.marketGroups[0].project.reconciliationReportDate);
+  if (!hasAppliedDefaultDates.value) {
+    if (!route.query.dateFrom && !route.query.dateTo) {
+      setDateFrom(data.marketGroups[0].project.reconciliationReportDate);
+    }
+    hasAppliedDefaultDates.value = true;
   }
 
   return data.marketGroups[0];

--- a/Sig.App.Frontend/src/views/report/SubscriptionEndReport.vue
+++ b/Sig.App.Frontend/src/views/report/SubscriptionEndReport.vue
@@ -81,6 +81,7 @@ const searchInput = ref({
   selectedSubscriptions: []
 });
 const page = ref(1);
+const hasAppliedDefaultDates = ref(Boolean(route.query.dateFrom || route.query.dateTo));
 const availableSubscriptions = ref([]);
 const availableOrganizations = ref([]);
 
@@ -199,8 +200,11 @@ const { result: resultProjects, loading: loadingProjects } = useQuery(
 );
 
 const project = useResult(resultProjects, null, (data) => {
-  if (!route.query.dateFrom && !route.query.dateTo) {
-    setDateFrom(data.projects[0].reconciliationReportDate);
+  if (!hasAppliedDefaultDates.value) {
+    if (!route.query.dateFrom && !route.query.dateTo) {
+      setDateFrom(data.projects[0].reconciliationReportDate);
+    }
+    hasAppliedDefaultDates.value = true;
   }
 
   availableOrganizations.value = data.projects[0].organizations;
@@ -269,8 +273,11 @@ const { result: resultOrganizations, loading: loadingOrganizations } = useQuery(
 );
 
 const organization = useResult(resultOrganizations, null, (data) => {
-  if (!route.query.dateFrom && !route.query.dateTo) {
-    setDateFrom(data.organizations[0].subscriptionEndReportDate);
+  if (!hasAppliedDefaultDates.value) {
+    if (!route.query.dateFrom && !route.query.dateTo) {
+      setDateFrom(data.organizations[0].subscriptionEndReportDate);
+    }
+    hasAppliedDefaultDates.value = true;
   }
 
   availableSubscriptions.value = data.organizations[0].budgetAllowances.map((x) => x.subscription);


### PR DESCRIPTION
# [JIRA - Ajouter un bouton pour le mois en cours au rapport de réconciliation #237](https://sigmund-ca.atlassian.net/browse/CRCL-2525)

Un partenaire souhaitait accéder plus rapidement au mois en cours dans le rapport de réconciliation. Cette PR ajoute un raccourci **« Mois en cours »** aux filtres de dates des rapports, et corrige un bug où le premier clic sur un preset ne mettait à jour que la date de fin.

## Changements

### Frontend
- `report-filters.vue` : bouton **« Mois en cours »** / **« Current month »** (1er → dernier jour du mois calendaire en cours)
- `report-filters.vue` : correction de `:min-date` sur le sélecteur de date de fin (`props.modelValue.dateFrom`)
- `ReconciliationReport.vue`, `BudgetAllowanceReport.vue`, `SubscriptionEndReport.vue` : flag `hasAppliedDefaultDates` pour n'appliquer la période par défaut du projet qu'au chargement initial (évite l'écrasement de `dateFrom` au premier clic sur un preset)

## Test plan
- [ ] Ouvrir `/reconciliation-report` sans paramètres URL : la période par défaut du projet s'affiche
- [ ] Au **premier** clic sur **« Mois en cours »** : `dateFrom` = 1er du mois et `dateTo` = dernier jour du mois
- [ ] Au premier clic sur les autres presets (**Mois dernier**, **Année en cours**, etc.) : les deux dates se mettent à jour
- [ ] L'URL se met à jour avec `?dateFrom=` et `?dateTo=`
- [ ] Le tableau se recharge avec les montants dus pour la période sélectionnée
- [ ] Libellés FR/EN corrects selon la langue active
- [ ] **Réinitialiser** remet la période par défaut (comportement inchangé)