### PR TITLE
Block empty participant category association keys (CRCL-2108)

### DIFF
--- a/Sig.App.Backend/DbModel/Entities/Beneficiaries/BeneficiaryType.cs
+++ b/Sig.App.Backend/DbModel/Entities/Beneficiaries/BeneficiaryType.cs
@@ -1,4 +1,4 @@
-﻿using Sig.App.Backend.DbModel.Entities.Projects;
+using Sig.App.Backend.DbModel.Entities.Projects;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,7 +23,11 @@ namespace Sig.App.Backend.DbModel.Entities.Beneficiaries
 
         public void SetKeys(string[] keys)
         {
-            Keys = string.Join(";", keys.Distinct().Select(x => x.Trim().ToLower()));
+            Keys = string.Join(";",
+                keys
+                    .Where(k => !string.IsNullOrWhiteSpace(k))
+                    .Select(x => x.Trim().ToLower())
+                    .Distinct());
         }
     }
 }

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/AddBeneficiaryTypeInProject.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/AddBeneficiaryTypeInProject.cs
@@ -1,4 +1,4 @@
-﻿using MediatR;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Sig.App.Backend.DbModel;
 using Sig.App.Backend.Plugins.GraphQL;
@@ -36,6 +36,12 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
             {
                 logger.LogWarning("[Mutation] AddBeneficiaryTypeInProject - ProjectNotFoundException");
                 throw new ProjectNotFoundException();
+            }
+
+            if (request.Keys == null || !request.Keys.Any() || request.Keys.Any(string.IsNullOrWhiteSpace))
+            {
+                logger.LogWarning("[Mutation] AddBeneficiaryTypeInProject - BeneficiaryTypeKeysCantBeEmptyException");
+                throw new BeneficiaryTypeKeysCantBeEmptyException();
             }
 
             var beneficiaryTypes = await db.BeneficiaryTypes.Where(x => x.ProjectId == projectId).ToListAsync();
@@ -81,5 +87,6 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
         public class ProjectNotFoundException : RequestValidationException { }
         public class BeneficiaryTypeKeyAlreadyInUseException : RequestValidationException { }
+        public class BeneficiaryTypeKeysCantBeEmptyException : RequestValidationException { }
     }
 }

--- a/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiaryType.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Beneficiaries/EditBeneficiaryType.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Conventions;
+using GraphQL.Conventions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -39,6 +39,12 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
                 throw new BeneficiaryTypeNotFoundException();
             }
 
+            if (request.Keys == null || !request.Keys.Any() || request.Keys.Any(string.IsNullOrWhiteSpace))
+            {
+                logger.LogWarning("[Mutation] EditBeneficiaryType - BeneficiaryTypeKeysCantBeEmptyException");
+                throw new BeneficiaryTypeKeysCantBeEmptyException();
+            }
+
             var beneficiaryTypes = await db.BeneficiaryTypes.Where(x => x.ProjectId == beneficiaryType.ProjectId && x.Id != beneficiaryType.Id).ToListAsync();
             var beneficiaryTypesKeys = beneficiaryTypes.SelectMany(x => x.GetKeys());
 
@@ -76,5 +82,6 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Beneficiaries
 
         public class BeneficiaryTypeNotFoundException : RequestValidationException { }
         public class BeneficiaryTypeKeyAlreadyInUseException: RequestValidationException { }
+        public class BeneficiaryTypeKeysCantBeEmptyException : RequestValidationException { }
     }
 }

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Beneficiaries/AddBeneficiaryTypeInProjectTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Beneficiaries/AddBeneficiaryTypeInProjectTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using GraphQL.Conventions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -103,6 +103,48 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Beneficiaries
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<AddBeneficiaryTypeInProject.BeneficiaryTypeKeyAlreadyInUseException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfKeysIsEmpty()
+        {
+            var input = new AddBeneficiaryTypeInProject.Input()
+            {
+                ProjectId = project.GetIdentifier(),
+                Keys = [],
+                Name = "Type ABCD"
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<AddBeneficiaryTypeInProject.BeneficiaryTypeKeysCantBeEmptyException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfKeyIsWhitespaceOnly()
+        {
+            var input = new AddBeneficiaryTypeInProject.Input()
+            {
+                ProjectId = project.GetIdentifier(),
+                Keys = ["   "],
+                Name = "Type ABCD"
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<AddBeneficiaryTypeInProject.BeneficiaryTypeKeysCantBeEmptyException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfOneKeyIsWhitespaceOnly()
+        {
+            var input = new AddBeneficiaryTypeInProject.Input()
+            {
+                ProjectId = project.GetIdentifier(),
+                Keys = ["couple", "   "],
+                Name = "Type ABCD"
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<AddBeneficiaryTypeInProject.BeneficiaryTypeKeysCantBeEmptyException>();
         }
     }
 }

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Beneficiaries/EditBeneficiaryTypeTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Beneficiaries/EditBeneficiaryTypeTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using GraphQL.Conventions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -111,6 +111,48 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Beneficiaries
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<EditBeneficiaryType.BeneficiaryTypeKeyAlreadyInUseException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfKeysIsEmpty()
+        {
+            var input = new EditBeneficiaryType.Input()
+            {
+                BeneficiaryTypeId = beneficiaryType.GetIdentifier(),
+                Name = new Maybe<NonNull<string>>("Type EFGH"),
+                Keys = []
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<EditBeneficiaryType.BeneficiaryTypeKeysCantBeEmptyException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfKeyIsWhitespaceOnly()
+        {
+            var input = new EditBeneficiaryType.Input()
+            {
+                BeneficiaryTypeId = beneficiaryType.GetIdentifier(),
+                Name = new Maybe<NonNull<string>>("Type EFGH"),
+                Keys = ["   "]
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<EditBeneficiaryType.BeneficiaryTypeKeysCantBeEmptyException>();
+        }
+
+        [Fact]
+        public async Task ThrowsIfOneKeyIsWhitespaceOnly()
+        {
+            var input = new EditBeneficiaryType.Input()
+            {
+                BeneficiaryTypeId = beneficiaryType.GetIdentifier(),
+                Name = new Maybe<NonNull<string>>("Type EFGH"),
+                Keys = ["couple", "   "]
+            };
+
+            await F(() => handler.Handle(input, CancellationToken.None))
+                .Should().ThrowAsync<EditBeneficiaryType.BeneficiaryTypeKeysCantBeEmptyException>();
         }
     }
 }

--- a/Sig.App.Frontend/src/views/category/AddCategory.vue
+++ b/Sig.App.Frontend/src/views/category/AddCategory.vue
@@ -4,13 +4,15 @@
 		"add-category": "Add category",
 		"add-category-success-notification": "Category {categoryName} has been successfully added.",
 		"title": "Add Category",
-    "beneficiary-type-key-already-in-use": "One of the keys you've entered is already associated with another category."
+    "beneficiary-type-key-already-in-use": "One of the keys you've entered is already associated with another category.",
+    "beneficiary-type-keys-cant-be-empty": "At least one valid key is required."
 	},
 	"fr": {
 		"add-category": "Ajouter la catégorie",
 		"add-category-success-notification": "L'ajout de la catégorie {categoryName} a été un succès.",
 		"title": "Ajouter une catégorie",
-    "beneficiary-type-key-already-in-use": "L'une des clés que vous avez saisies est déjà associée à une autre catégorie."
+    "beneficiary-type-key-already-in-use": "L'une des clés que vous avez saisies est déjà associée à une autre catégorie.",
+    "beneficiary-type-keys-cant-be-empty": "Au moins une clé valide est requise."
 	}
 }
 </i18n>
@@ -40,6 +42,9 @@ import CategoryForm from "@/views/category/_Form.vue";
 useGraphQLErrorMessages({
   BENEFICIARY_TYPE_KEY_ALREADY_IN_USE: () => {
     return t("beneficiary-type-key-already-in-use");
+  },
+  BENEFICIARY_TYPE_KEYS_CANT_BE_EMPTY: () => {
+    return t("beneficiary-type-keys-cant-be-empty");
   }
 });
 

--- a/Sig.App.Frontend/src/views/category/AddCategory.vue
+++ b/Sig.App.Frontend/src/views/category/AddCategory.vue
@@ -38,6 +38,7 @@ import { URL_CATEGORY_ADMIN } from "@/lib/consts/urls";
 import { useGraphQLErrorMessages } from "@/lib/helpers/error-handler";
 
 import CategoryForm from "@/views/category/_Form.vue";
+import { CATEGORY_PROJECTS_QUERY } from "@/views/category/category-projects.query";
 
 useGraphQLErrorMessages({
   BENEFICIARY_TYPE_KEY_ALREADY_IN_USE: () => {
@@ -68,13 +69,18 @@ const { mutate: addBeneficiaryTypeInProject } = useMutation(
 );
 
 async function onSubmit({ categoryName, categoryKeys }) {
-  await addBeneficiaryTypeInProject({
-    input: {
-      projectId: route.query.projectId,
-      name: categoryName,
-      keys: categoryKeys.map((x) => x.name)
+  await addBeneficiaryTypeInProject(
+    {
+      input: {
+        projectId: route.query.projectId,
+        name: categoryName,
+        keys: categoryKeys.map((x) => x.name)
+      }
+    },
+    {
+      refetchQueries: [{ query: CATEGORY_PROJECTS_QUERY }]
     }
-  });
+  );
   router.push({ name: URL_CATEGORY_ADMIN });
   addSuccess(t("add-category-success-notification", { categoryName }));
 }

--- a/Sig.App.Frontend/src/views/category/DeleteCategory.vue
+++ b/Sig.App.Frontend/src/views/category/DeleteCategory.vue
@@ -36,6 +36,7 @@ import { useRoute, useRouter } from "vue-router";
 
 import { useNotificationsStore } from "@/lib/store/notifications";
 import { URL_CATEGORY_ADMIN } from "@/lib/consts/urls";
+import { CATEGORY_PROJECTS_QUERY } from "@/views/category/category-projects.query";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -70,11 +71,16 @@ function getCategoryName() {
 }
 
 async function deleteCategory() {
-  await deleteBeneficiaryTypeMutation({
-    input: {
-      beneficiaryTypeId: route.params.categoryId
+  await deleteBeneficiaryTypeMutation(
+    {
+      input: {
+        beneficiaryTypeId: route.params.categoryId
+      }
+    },
+    {
+      refetchQueries: [{ query: CATEGORY_PROJECTS_QUERY }]
     }
-  });
+  );
 
   addSuccess(t("delete-category-success-notification", { categoryName: category.value.name }));
   router.push({ name: URL_CATEGORY_ADMIN });

--- a/Sig.App.Frontend/src/views/category/EditCategory.vue
+++ b/Sig.App.Frontend/src/views/category/EditCategory.vue
@@ -4,13 +4,15 @@
 		"add-category": "Edit",
 		"add-category-success-notification": "The category {categoryName} has been successfully updated.",
 		"title": "Edit Category",
-    "beneficiary-type-key-already-in-use": "One of the keys you've entered is already associated with another category."
+    "beneficiary-type-key-already-in-use": "One of the keys you've entered is already associated with another category.",
+    "beneficiary-type-keys-cant-be-empty": "At least one valid key is required."
 	},
 	"fr": {
 		"add-category": "Modifier",
 		"add-category-success-notification": "La modification de la catégorie {categoryName} a été un succès.",
 		"title": "Modifier une catégorie",
-    "beneficiary-type-key-already-in-use": "L'une des clés que vous avez saisies est déjà associée à une autre catégorie."
+    "beneficiary-type-key-already-in-use": "L'une des clés que vous avez saisies est déjà associée à une autre catégorie.",
+    "beneficiary-type-keys-cant-be-empty": "Au moins une clé valide est requise."
 	}
 }
 </i18n>
@@ -44,6 +46,9 @@ import CategoryForm from "@/views/category/_Form.vue";
 useGraphQLErrorMessages({
   BENEFICIARY_TYPE_KEY_ALREADY_IN_USE: () => {
     return t("beneficiary-type-key-already-in-use");
+  },
+  BENEFICIARY_TYPE_KEYS_CANT_BE_EMPTY: () => {
+    return t("beneficiary-type-keys-cant-be-empty");
   }
 });
 

--- a/Sig.App.Frontend/src/views/category/ListCategories.vue
+++ b/Sig.App.Frontend/src/views/category/ListCategories.vue
@@ -35,7 +35,6 @@
 
 <script setup>
 import { computed, defineEmits, onBeforeMount } from "vue";
-import gql from "graphql-tag";
 import { useI18n } from "vue-i18n";
 import { useQuery, useResult } from "@vue/apollo-composable";
 
@@ -44,29 +43,14 @@ import { usePageTitle } from "@/lib/helpers/page-title";
 import { URL_CATEGORY_ADD } from "@/lib/consts/urls";
 
 import CategoryTable from "@/components/category/category-table";
+import { CATEGORY_PROJECTS_QUERY } from "@/views/category/category-projects.query";
 
 const { t } = useI18n();
 const emit = defineEmits(["isLoading", "loadingFinish"]);
 
 usePageTitle(t("title"));
 
-const { result, refetch } = useQuery(
-  gql`
-    query Projects {
-      projects {
-        id
-        beneficiaryTypes {
-          id
-          name
-          keys
-          beneficiaries {
-            id
-          }
-        }
-      }
-    }
-  `
-);
+const { result, refetch } = useQuery(CATEGORY_PROJECTS_QUERY);
 const projects = useResult(result, null, (data) => {
   if (data.projects !== null) {
     emit("loadingFinish");

--- a/Sig.App.Frontend/src/views/category/_Form.vue
+++ b/Sig.App.Frontend/src/views/category/_Form.vue
@@ -25,14 +25,14 @@
 
 <template>
   <Form
-    v-slot="{ isSubmitting, errors: formErrors }"
+    v-slot="{ isSubmitting, errors: formErrors, values }"
     :validation-schema="validationSchema"
     :initial-values="initialValues"
     @submit="onSubmit">
     <PfForm
       has-footer
       can-cancel
-      :disable-submit="Object.keys(formErrors).length > 0"
+      :disable-submit="!values.categoryKeys?.length || Object.keys(formErrors).length > 0"
       :submit-label="props.submitBtn"
       :cancel-label="t('cancel')"
       :processing="isSubmitting"
@@ -120,12 +120,15 @@ const initialValues = {
 
 const validationSchema = computed(() =>
   object({
-    categoryName: string().label(t("category-name")).required(),
-    categoryKeys: array().of(
-      object({
-        name: string().label(t("keyword-name")).required()
-      })
-    )
+    categoryName: string().label(t("category-name")).trim().required(),
+    categoryKeys: array()
+      .label(t("keywords-section-title"))
+      .min(1)
+      .of(
+        object({
+          name: string().label(t("keyword-name")).trim().required()
+        })
+      )
   })
 );
 

--- a/Sig.App.Frontend/src/views/category/category-projects.query.js
+++ b/Sig.App.Frontend/src/views/category/category-projects.query.js
@@ -1,0 +1,17 @@
+import gql from "graphql-tag";
+
+export const CATEGORY_PROJECTS_QUERY = gql`
+  query Projects {
+    projects {
+      id
+      beneficiaryTypes {
+        id
+        name
+        keys
+        beneficiaries {
+          id
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# [JIRA - Ne pas permettre de créer une clés d'association vide](https://sigmund-ca.atlassian.net/browse/CRCL-2108)

Les clés de correspondance d'une catégorie de participant pouvaient être enregistrées vides en saisissant uniquement des espaces. La liste des catégories ne se rafraîchissait pas non plus après un ajout ou une suppression.

## Changements

### Frontend
- `_Form.vue` : validation Yup renforcée (`.trim().required()`, `.min(1)` sur les clés) et bouton de soumission désactivé si aucune clé
- `AddCategory.vue` / `EditCategory.vue` : messages d'erreur pour `BENEFICIARY_TYPE_KEYS_CANT_BE_EMPTY`
- `AddCategory.vue` / `DeleteCategory.vue` : `refetchQueries` explicite après mutation réussie
- `category-projects.query.js` : requête GraphQL partagée pour la liste des catégories

### Backend
- `BeneficiaryType.SetKeys()` : filtre les clés whitespace-only avant persistance
- `AddBeneficiaryTypeInProject` / `EditBeneficiaryType` : rejet si `Keys` est vide, null ou contient une entrée whitespace-only
- Nouvelle exception `BeneficiaryTypeKeysCantBeEmptyException` → code GraphQL `BENEFICIARY_TYPE_KEYS_CANT_BE_EMPTY`

### Tests
- 6 nouveaux cas unitaires (tableau vide, clé avec espaces seulement, clé mixte valide + espaces) pour les mutations add/edit

## Test plan

- [ ] Ajouter une catégorie avec une clé contenant uniquement des espaces → soumission bloquée, message d'erreur sur le champ « Clé »
- [ ] Supprimer toutes les clés du formulaire → message « Au moins une clé est requise », bouton désactivé
- [ ] Ajouter une catégorie avec une clé valide (ex. `couple`) → création réussie, liste rafraîchie
- [ ] Modifier une catégorie existante en remplaçant une clé par des espaces → même blocage
- [ ] Supprimer une catégorie → liste rafraîchie sans rechargement manuel de la page
- [ ] (Optionnel) Appel GraphQL direct avec `keys: ["   "]` → erreur `BENEFICIARY_TYPE_KEYS_CANT_BE_EMPTY`
