### PR TITLE
Corriger l'affichage du bouton 'Exporter tous les participants' dans le menu

### DIFF
--- a/Sig.App.Frontend/src/components/app/secondary-menu.vue
+++ b/Sig.App.Frontend/src/components/app/secondary-menu.vue
@@ -87,8 +87,7 @@
         :icon="MARKET" />
       <button
         v-if="manageProjectManagers && manageBeneficiaries"
-        class="secondary-menu-item secondary-menu-item--is-inactive"
-        style="width: 285px"
+        class="secondary-menu-item secondary-menu-item--is-inactive text-start w-full"
         @click="onExportReport">
         {{ t("manage-project-export-all-participants") }}
       </button>


### PR DESCRIPTION
# [JIRA - Fixer l'effet over du bouton d'exportation des participants pour être raccord (CRCL-1980)](https://sigmund-ca.atlassian.net/browse/CRCL-1980)

Simple ajustement CSS

| Avant: | Après: |
| ------- | ------- |
| <img width="268" height="453" alt="avant" src="https://github.com/user-attachments/assets/08d1d698-f308-456a-9f1b-f0dbb54154ea" /> | <img width="268" height="453" alt="après" src="https://github.com/user-attachments/assets/29cb1db7-1104-42c6-b8dd-19b86a6890ef" /> |

