### PR TITLE
Corrections suite à des erreurs observées dans Stackify

### DIFF
--- a/Sig.App.Backend/Authorization/RequirePermissionAttribute.cs
+++ b/Sig.App.Backend/Authorization/RequirePermissionAttribute.cs
@@ -101,53 +101,61 @@ namespace Sig.App.Backend.Authorization
 
         private async Task<bool> HasProjectPermission(ClaimsPrincipal claimsPrincipal, ProjectPermission permission, object input)
         {
-            var projectPermissions = await permissionService.GetProjectPermissions(claimsPrincipal, GetProjectIdFromInput(input));
+            var id = await GetProjectIdFromInput(input);
+            var projectPermissions = await permissionService.GetProjectPermissions(claimsPrincipal, id);
             return projectPermissions.Contains(permission);
         }
 
         private async Task<bool> HasMarketPermission(ClaimsPrincipal claimsPrincipal, MarketPermission permission, object input)
         {
-            var marketPermissions = await permissionService.GetMarketPermissions(claimsPrincipal, GetMarketIdFromInput(input));
+            var id = await GetMarketIdFromInput(input);
+            var marketPermissions = await permissionService.GetMarketPermissions(claimsPrincipal, id);
             return marketPermissions.Contains(permission);
         }
 
         private async Task<bool> HasOrganizationPermission(ClaimsPrincipal claimsPrincipal, OrganizationPermission permission, object input)
         {
-            var organizationPermissions = await permissionService.GetOrganizationPermissions(claimsPrincipal, GetOrganizationIdFromInput(input));
+            var id = await GetOrganizationIdFromInput(input);
+            var organizationPermissions = await permissionService.GetOrganizationPermissions(claimsPrincipal, id);
             return organizationPermissions.Contains(permission);
         }
 
         private async Task<bool> HasBeneficiaryPermissions(ClaimsPrincipal claimsPrincipal, BeneficiaryPermission permission, object input)
         {
-            var beneficiaryPermissions = await permissionService.GetBeneficiaryPermissions(claimsPrincipal, GetBeneficiaryIdFromInput(input));
+            var id = await GetBeneficiaryIdFromInput(input);
+            var beneficiaryPermissions = await permissionService.GetBeneficiaryPermissions(claimsPrincipal, id);
             return beneficiaryPermissions.Contains(permission);
         }
 
         private async Task<bool> HasSubscriptionPermissions(ClaimsPrincipal claimsPrincipal, SubscriptionPermission permission, object input)
         {
-            var subscriptionPermissions = await permissionService.GetSubscriptionPermissions(claimsPrincipal, GetSubscriptionIdFromInput(input));
+            var id = GetSubscriptionIdFromInput(input);
+            var subscriptionPermissions = await permissionService.GetSubscriptionPermissions(claimsPrincipal, id);
             return subscriptionPermissions.Contains(permission);
         }
 
         private async Task<bool> HasBeneficiaryTypePermissions(ClaimsPrincipal claimsPrincipal, BeneficiaryTypePermission permission, object input)
         {
-            var beneficiaryTypePermissions = await permissionService.GetBeneficiaryTypePermissions(claimsPrincipal, GetBeneficiaryTypeIdFromInput(input));
+            var id = GetBeneficiaryTypeIdFromInput(input);
+            var beneficiaryTypePermissions = await permissionService.GetBeneficiaryTypePermissions(claimsPrincipal, id);
             return beneficiaryTypePermissions.Contains(permission);
         }
 
         private async Task<bool> HasCardPermissions(ClaimsPrincipal claimsPrincipal, CardPermission permission, object input)
         {
-            var cardPermissions = await permissionService.GetCardPermissions(claimsPrincipal, GetCardIdFromInput(input));
+            var id = GetCardIdFromInput(input);
+            var cardPermissions = await permissionService.GetCardPermissions(claimsPrincipal, id);
             return cardPermissions.Contains(permission);
         }
 
         private async Task<bool> HasMarketGroupPermissions(ClaimsPrincipal claimsPrincipal, MarketGroupPermission permission, object input)
         {
-            var marketGroupPermissions = await permissionService.GetMarketGroupPermissions(claimsPrincipal, GetMarketGroupIdFromInput(input));
+            var id = GetMarketGroupIdFromInput(input);
+            var marketGroupPermissions = await permissionService.GetMarketGroupPermissions(claimsPrincipal, id);
             return marketGroupPermissions.Contains(permission);
         }
 
-        private string GetProjectIdFromInput(object input)
+        private async Task<string> GetProjectIdFromInput(object input)
         {
             if (input is HaveProjectId hpi)
             {
@@ -159,8 +167,11 @@ namespace Sig.App.Backend.Authorization
             }
             if (input is HaveOrganizationIdAndMarketId hoiami)
             {
-                var organization = db.Organizations.Include(x => x.Project).Where(x => x.Id == hoiami.OrganizationId.LongIdentifierForType<Organization>()).FirstOrDefault();
-                return organization.Project.GetIdentifier().IdentifierForType<Project>();
+                var organization = await db.Organizations
+                    .Include(x => x.Project)
+                    .Where(x => x.Id == hoiami.OrganizationId.LongIdentifierForType<Organization>())
+                    .FirstOrDefaultAsync();
+                return organization?.Project.GetIdentifier().IdentifierForType<Project>();
             }
             if (input is ProjectGraphType pgt)
             {
@@ -169,7 +180,7 @@ namespace Sig.App.Backend.Authorization
             if (input is HaveCardId hci)
             {
                 var cardId = hci.CardId.LongIdentifierForType<Card>();
-                var card = db.Cards.Find(cardId);
+                var card = await db.Cards.FindAsync(cardId);
                 if (card != null)
                 {
                     var projectId = Id.New<Project>(card.ProjectId);
@@ -184,17 +195,24 @@ namespace Sig.App.Backend.Authorization
             return null;
         }
 
-        private string GetMarketIdFromInput(object input)
+        private async Task<string> GetMarketIdFromInput(object input)
         {
             if (input is HaveInitialTransactionId hiti)
             {
-                var transaction = db.Transactions.OfType<PaymentTransaction>().Include(x => x.Market).Where(x => x.Id == hiti.InitialTransactionId.LongIdentifierForType<PaymentTransaction>()).FirstOrDefault();
-                return transaction.Market.GetIdentifier().IdentifierForType<Market>();
+                var transaction = await db.Transactions
+                    .OfType<PaymentTransaction>()
+                    .Include(x => x.Market)
+                    .Where(x => x.Id == hiti.InitialTransactionId.LongIdentifierForType<PaymentTransaction>())
+                    .FirstOrDefaultAsync();
+                return transaction?.Market.GetIdentifier().IdentifierForType<Market>();
             }
             if (input is HaveCashRegisterId hcri)
             {
-                var cashRegister = db.CashRegisters.Include(x => x.Market).Where(x => x.Id == hcri.CashRegisterId.LongIdentifierForType<CashRegister>()).FirstOrDefault();
-                return cashRegister.Market.GetIdentifier().IdentifierForType<Market>();
+                var cashRegister = await db.CashRegisters
+                    .Include(x => x.Market)
+                    .Where(x => x.Id == hcri.CashRegisterId.LongIdentifierForType<CashRegister>())
+                    .FirstOrDefaultAsync();
+                return cashRegister?.Market.GetIdentifier().IdentifierForType<Market>();
             }
             if (input is HaveMarketId hmi)
             {
@@ -224,7 +242,7 @@ namespace Sig.App.Backend.Authorization
             return null;
         }
 
-        private string GetOrganizationIdFromInput(object input)
+        private async Task<string> GetOrganizationIdFromInput(object input)
         {
             if (input is HaveOrganizationId hoi)
             {
@@ -244,8 +262,11 @@ namespace Sig.App.Backend.Authorization
             }
             if (input is HaveSubscriptionIdAndBeneficiaryId hsiabi)
             {
-                var beneficiary = db.Beneficiaries.Include(x => x.Organization).Where(x => x.Id == hsiabi.BeneficiaryId.LongIdentifierForType<Beneficiary>()).FirstOrDefault();
-                return beneficiary.Organization.GetIdentifier().IdentifierForType<Organization>();
+                var beneficiary = await db.Beneficiaries
+                    .Include(x => x.Organization)
+                    .Where(x => x.Id == hsiabi.BeneficiaryId.LongIdentifierForType<Beneficiary>())
+                    .FirstOrDefaultAsync();
+                return beneficiary?.Organization.GetIdentifier().IdentifierForType<Organization>();
             }
             if (input is Id id)
             {
@@ -255,7 +276,7 @@ namespace Sig.App.Backend.Authorization
             return null;
         }
 
-        private string GetBeneficiaryIdFromInput(object input)
+        private async Task<string> GetBeneficiaryIdFromInput(object input)
         {
             if (input is HaveBeneficiaryId hbi)
             {
@@ -292,7 +313,10 @@ namespace Sig.App.Backend.Authorization
             }
             if (input is HaveOriginalCardId hoci)
             {
-                var beneficiary = db.Cards.Include(x => x.Beneficiary).Where(x => x.Id == hoci.OriginalCardId.LongIdentifierForType<Card>()).FirstOrDefault().Beneficiary;
+                var beneficiary = (await db.Cards
+                    .Include(x => x.Beneficiary)
+                    .Where(x => x.Id == hoci.OriginalCardId.LongIdentifierForType<Card>())
+                    .FirstOrDefaultAsync())?.Beneficiary;
                 if (beneficiary is OffPlatformBeneficiary)
                 {
                     return beneficiary.GetIdentifier().IdentifierForType<OffPlatformBeneficiary>();

--- a/Sig.App.Backend/Authorization/RequirePermissionAttribute.cs
+++ b/Sig.App.Backend/Authorization/RequirePermissionAttribute.cs
@@ -52,7 +52,7 @@ namespace Sig.App.Backend.Authorization
 
             var currentUser = await userManager.FindByIdAsync(appUserContext.CurrentUser.GetUserId());
 
-            if (currentUser.Status == DbModel.Enums.UserStatus.Actived)
+            if (currentUser?.Status == DbModel.Enums.UserStatus.Actived)
             {
                 foreach (var permission in permissions)
                 {

--- a/Sig.App.Backend/Services/Permission/PermissionService.cs
+++ b/Sig.App.Backend/Services/Permission/PermissionService.cs
@@ -237,57 +237,62 @@ namespace Sig.App.Backend.Services.Permission
         };
 
 
-
-        public Task<GlobalPermission[]> GetGlobalPermissions(ClaimsPrincipal claimsPrincipal)
+        private const string UserTypePCAAdmin = nameof(UserType.PCAAdmin);
+        private const string UserTypeProjectManager = nameof(UserType.ProjectManager);
+        private const string UserTypeOrganizationManager = nameof(UserType.OrganizationManager);
+        private const string UserTypeMerchant = nameof(UserType.Merchant);
+        private const string UserTypeMarketGroupManager = nameof(UserType.MarketGroupManager);
+        
+        public async Task<GlobalPermission[]> GetGlobalPermissions(ClaimsPrincipal claimsPrincipal)
         {
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.PCAAdmin.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypePCAAdmin))
             {
-                return Task.FromResult(AdminGlobalPermissions);
+                return AdminGlobalPermissions;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager))
             {
                 var claim = claimsPrincipal.Claims.FirstOrDefault(x => x.Type == AppClaimTypes.ProjectManagerOf);
-                var projectId = (long)Convert.ToDouble(claim.Value);
-                var project = db.Projects.FirstOrDefault(x => x.Id == projectId);
+                var projectId = Convert.ToInt64(claim?.Value);
+                var project = await db.Projects.FirstOrDefaultAsync(x => x.Id == projectId);
                 if (project.AdministrationSubscriptionsOffPlatform)
                 {
-                    return Task.FromResult(ProjectManagerSubscriptionsOffPlatformGlobalPermissions);
+                    return ProjectManagerSubscriptionsOffPlatformGlobalPermissions;
                 }
 
-                return Task.FromResult(ProjectManagerGlobalPermissions);
+                return ProjectManagerGlobalPermissions;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.OrganizationManager.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeOrganizationManager))
             {
                 var claim = claimsPrincipal.Claims.FirstOrDefault(x => x.Type == AppClaimTypes.OrganizationManagerOf);
                 if (claim != null)
                 {
-                    var organizationId = (long)Convert.ToDouble(claim.Value);
-                    var project = db.Projects.FirstOrDefault(x => x.Organizations.Any(y => y.Id == organizationId));
+                    var organizationId = Convert.ToInt64(claim.Value);
+                    var project = await db.Projects.FirstOrDefaultAsync(x => x.Organizations.Any(y => y.Id == organizationId));
 
                     if (project != null && project.AllowOrganizationsAssignCards)
                     {
                         var result = new List<GlobalPermission>() { GlobalPermission.ManageCards };
                         result.AddRange(OrganizationManagerGlobalPermissions);
-                        return Task.FromResult(result.ToArray());
+                        return result.ToArray();
                     }
                 }
 
-                return Task.FromResult(OrganizationManagerGlobalPermissions);
+                return OrganizationManagerGlobalPermissions;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.Merchant.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeMerchant))
             {
-                return Task.FromResult(MarketManagerGlobalPermissions);
+                return MarketManagerGlobalPermissions;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.MarketGroupManager.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeMarketGroupManager))
             {
-                return Task.FromResult(MarketGroupManagerGlobalPermissions);
+                return MarketGroupManagerGlobalPermissions;
             }
 
-            return Task.FromResult(Array.Empty<GlobalPermission>());
+            return Array.Empty<GlobalPermission>();
         }
 
         public PermissionService(AppDbContext db)
@@ -295,26 +300,27 @@ namespace Sig.App.Backend.Services.Permission
             this.db = db;
         }
 
-        public Task<BeneficiaryTypePermission[]> GetBeneficiaryTypePermissions(ClaimsPrincipal claimsPrincipal, long beneficiaryTypeId)
+        public async Task<BeneficiaryTypePermission[]> GetBeneficiaryTypePermissions(ClaimsPrincipal claimsPrincipal, long beneficiaryTypeId)
         {
-            var beneficiaryType = db.BeneficiaryTypes.Include(x => x.Project).First(x => x.Id == beneficiaryTypeId);
+            var beneficiaryType = await db.BeneficiaryTypes.Include(x => x.Project).FirstAsync(x => x.Id == beneficiaryTypeId);
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, beneficiaryType.Project.GetIdentifier().IdentifierForType<Project>()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && 
+                claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, beneficiaryType.Project.GetIdentifier().IdentifierForType<Project>()))
             {
-                return Task.FromResult(ProjectManagerBeneficiaryTypePermission);
+                return ProjectManagerBeneficiaryTypePermission;
             }
 
-            return Task.FromResult(Array.Empty<BeneficiaryTypePermission>());
+            return Array.Empty<BeneficiaryTypePermission>();
         }
 
         public Task<ProjectPermission[]> GetProjectPermissions(ClaimsPrincipal claimsPrincipal, string projectId)
         {
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.PCAAdmin.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypePCAAdmin))
             {
                 return Task.FromResult(AdminProjectPermission);
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId))
             {
                 return Task.FromResult(ProjectManagerProjectPermission);
             }
@@ -322,94 +328,94 @@ namespace Sig.App.Backend.Services.Permission
             return Task.FromResult(Array.Empty<ProjectPermission>());
         }
 
-        public Task<MarketPermission[]> GetMarketPermissions(ClaimsPrincipal claimsPrincipal, string marketId)
+        public async Task<MarketPermission[]> GetMarketPermissions(ClaimsPrincipal claimsPrincipal, string marketId)
         {
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.PCAAdmin.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypePCAAdmin))
             {
-                return Task.FromResult(AdminMarketPermissions);
+                return AdminMarketPermissions;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.Merchant.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.MarketManagerOf, marketId))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeMerchant) && claimsPrincipal.HasClaim(AppClaimTypes.MarketManagerOf, marketId))
             {
-                return Task.FromResult(MarketManagerMarketPermission);
+                return MarketManagerMarketPermission;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager))
             {
                 if (marketId != null)
                 {
                     var marketLongId = Id.New<Market>(marketId).LongIdentifierForType<Market>();
-                    var projectMarkets = db.ProjectMarkets.Where(x => x.MarketId == marketLongId).ToList();
+                    var projectMarkets = await db.ProjectMarkets.Where(x => x.MarketId == marketLongId).ToListAsync();
 
                     foreach (var projectMarket in projectMarkets)
                     {
                         if (claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectMarket.ProjectId.ToString()))
                         {
-                            return Task.FromResult(ProjectManagerMarketPermission);
+                            return ProjectManagerMarketPermission;
                         }
                     }
                 }
 
-                return Task.FromResult(ProjectManagerMarketPermissionGeneric);
+                return ProjectManagerMarketPermissionGeneric;
             }
             
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.OrganizationManager.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeOrganizationManager))
             {
                 var marketLongId = Id.New<Market>(marketId).LongIdentifierForType<Market>();
-                var projectMarkets = db.ProjectMarkets.Where(x => x.MarketId == marketLongId).ToList();
-                var organizationForProjects = db.Organizations.Where(x => projectMarkets.Select(y => y.ProjectId).Contains(x.ProjectId)).ToList();
+                var projectMarkets = await db.ProjectMarkets.Where(x => x.MarketId == marketLongId).ToListAsync();
+                var organizationForProjects = await db.Organizations.Where(x => projectMarkets.Select(y => y.ProjectId).Contains(x.ProjectId)).ToListAsync();
 
                 foreach (var organization in organizationForProjects)
                 {
                     if (claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, organization.GetIdentifier().IdentifierForType<Organization>()))
                     {
-                        return Task.FromResult(OrganizationManagerMarketPermission);
+                        return OrganizationManagerMarketPermission;
                     }
                 }
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.MarketGroupManager.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeMarketGroupManager))
             {
                 if (!string.IsNullOrEmpty(marketId))
                 { 
                     var marketLongId = Id.New<Market>(marketId).LongIdentifierForType<Market>();
-                    var marketGroupMarkets = db.MarketGroupMarkets.Where(x => x.MarketId == marketLongId).ToList();
+                    var marketGroupMarkets = await db.MarketGroupMarkets.Where(x => x.MarketId == marketLongId).ToListAsync();
 
                     foreach (var marketGroupMarket in marketGroupMarkets)
                     {
                         if (claimsPrincipal.HasClaim(AppClaimTypes.MarketGroupManagerOf, marketGroupMarket.MarketGroupId.ToString()))
                         {
-                            return Task.FromResult(MarketGroupManagerMarketPermission);
+                            return MarketGroupManagerMarketPermission;
                         }
                     }
                 }
 
-                return Task.FromResult(MarketGroupManagerCreateMarketPermission);
+                return MarketGroupManagerCreateMarketPermission;
             }
 
-            return Task.FromResult(Array.Empty<MarketPermission>());
+            return Array.Empty<MarketPermission>();
         }
 
-        public Task<OrganizationPermission[]> GetOrganizationPermissions(ClaimsPrincipal claimsPrincipal, string organizationId)
+        public async Task<OrganizationPermission[]> GetOrganizationPermissions(ClaimsPrincipal claimsPrincipal, string organizationId)
         {
             var organizationLongId = Id.New<Organization>(organizationId).LongIdentifierForType<Organization>();
-            var organization = db.Organizations.FirstOrDefault(x => x.Id == organizationLongId);
+            var organization = await db.Organizations.FirstOrDefaultAsync(x => x.Id == organizationLongId);
             var projectId = organization.ProjectId.ToString();
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId))
             {
-                return Task.FromResult(ProjectManagerOrganizationPermission);
+                return ProjectManagerOrganizationPermission;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.OrganizationManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, organizationId))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeOrganizationManager) && claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, organizationId))
             {
-                return Task.FromResult(OrganizationManagerOrganizationPermission);
+                return OrganizationManagerOrganizationPermission;
             }
 
-            return Task.FromResult(Array.Empty<OrganizationPermission>());
+            return Array.Empty<OrganizationPermission>();
         }
 
-        public Task<BeneficiaryPermission[]> GetBeneficiaryPermissions(ClaimsPrincipal claimsPrincipal, string beneficiaryId)
+        public async Task<BeneficiaryPermission[]> GetBeneficiaryPermissions(ClaimsPrincipal claimsPrincipal, string beneficiaryId)
         {
             long beneficiaryLongId;
             try {
@@ -419,83 +425,84 @@ namespace Sig.App.Backend.Services.Permission
             {
                 beneficiaryLongId = Id.New<OffPlatformBeneficiary>(beneficiaryId).LongIdentifierForType<OffPlatformBeneficiary>();
             }
-            var beneficiary = db.Beneficiaries.FirstOrDefault(x => x.Id == beneficiaryLongId);
+            var beneficiary = await db.Beneficiaries.FirstOrDefaultAsync(x => x.Id == beneficiaryLongId);
             var organizationId = beneficiary.OrganizationId.ToString();
-            var projectId = db.Organizations.Where(x => x.Id == beneficiary.OrganizationId).FirstOrDefault().ProjectId;
-            var project = db.Projects.FirstOrDefault(x => x.Id == projectId);
+            var project = await db.Organizations.Where(x => x.Id == beneficiary.OrganizationId).Select(x => x.Project).FirstOrDefaultAsync();
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, project.Id.ToString()))
             {
-                return Task.FromResult(ProjectManagerBeneficiaryPermissions);
+                return ProjectManagerBeneficiaryPermissions;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.OrganizationManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, organizationId))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeOrganizationManager) && claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, organizationId))
             {
-                if (db.Projects.First(x => x.Organizations.Any(y => y.Id == (long)Convert.ToDouble(organizationId))).AllowOrganizationsAssignCards)
+                var p = await db.Projects.FirstAsync(x => x.Organizations.Any(y => y.Id == Convert.ToInt64(organizationId)));
+                if (p.AllowOrganizationsAssignCards)
                 {
-                    return Task.FromResult(OrganizationManagerBeneficiaryPermissionsWithAssignCard);
+                    return OrganizationManagerBeneficiaryPermissionsWithAssignCard;
                 }
 
-                return Task.FromResult(OrganizationManagerBeneficiaryPermissions);
+                return OrganizationManagerBeneficiaryPermissions;
             }
 
-            return Task.FromResult(Array.Empty<BeneficiaryPermission>());
+            return Array.Empty<BeneficiaryPermission>();
         }
 
-        public Task<CardPermission[]> GetCardPermissions(ClaimsPrincipal claimsPrincipal, string cardId)
+        public async Task<CardPermission[]> GetCardPermissions(ClaimsPrincipal claimsPrincipal, string cardId)
         {
             var cardLongId = Id.New<Card>(cardId).LongIdentifierForType<Card>();
 
-            var card = db.Cards
+            var card = await db.Cards
                 .Include(x => x.Beneficiary)
                 .Include(x => x.Project)
-                .FirstOrDefault(x => x.Id == cardLongId);
+                .FirstOrDefaultAsync(x => x.Id == cardLongId);
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, card.ProjectId.ToString()) && (!card.Project?.BeneficiariesAreAnonymous ?? true))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, card.ProjectId.ToString()) && (!card.Project?.BeneficiariesAreAnonymous ?? true))
             {
-                return Task.FromResult(ProjectManagerCardPermissions);
+                return ProjectManagerCardPermissions;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.OrganizationManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, card.Beneficiary.OrganizationId.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeOrganizationManager) && claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, card.Beneficiary.OrganizationId.ToString()))
             {
-                if (db.Projects.First(x => x.Organizations.Any(y => y.Id == (long)Convert.ToDouble(card.Beneficiary.OrganizationId))).AllowOrganizationsAssignCards)
+                var p = db.Projects.First(x => x.Organizations.Any(y => y.Id == Convert.ToInt64(card.Beneficiary.OrganizationId)));
+                if (p.AllowOrganizationsAssignCards)
                 {
-                    return Task.FromResult(OrganizationManagerCardPermissionsWithAssignCard);
+                    return OrganizationManagerCardPermissionsWithAssignCard;
                 }
             }
 
-            return Task.FromResult(Array.Empty<CardPermission>());
+            return Array.Empty<CardPermission>();
         }
 
-        public Task<SubscriptionPermission[]> GetSubscriptionPermissions(ClaimsPrincipal claimsPrincipal, string subscriptionId)
+        public async Task<SubscriptionPermission[]> GetSubscriptionPermissions(ClaimsPrincipal claimsPrincipal, string subscriptionId)
         {
             var subscriptionLongId = Id.New<Subscription>(subscriptionId).LongIdentifierForType<Subscription>();
-            var projectId = db.Subscriptions.Where(x => x.Id == subscriptionLongId).FirstOrDefault().ProjectId.ToString();
+            var projectId = await db.Subscriptions.Where(x => x.Id == subscriptionLongId).Select(x => x.ProjectId).FirstOrDefaultAsync();
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId.ToString()))
             {
-                return Task.FromResult(ProjectManagerSubscriptionPermission);
+                return ProjectManagerSubscriptionPermission;
             }
 
-            return Task.FromResult(Array.Empty<SubscriptionPermission>());
+            return Array.Empty<SubscriptionPermission>();
         }
 
-        public Task<MarketGroupPermission[]> GetMarketGroupPermissions(ClaimsPrincipal claimsPrincipal, string marketGroupId)
+        public async Task<MarketGroupPermission[]> GetMarketGroupPermissions(ClaimsPrincipal claimsPrincipal, string marketGroupId)
         {
             var marketGroupLongId = Id.New<MarketGroup>(marketGroupId).LongIdentifierForType<MarketGroup>();
-            var projectId = db.MarketGroups.Where(x => x.Id == marketGroupLongId).FirstOrDefault().ProjectId.ToString();
+            var projectId = await db.MarketGroups.Where(x => x.Id == marketGroupLongId).Select(x => x.ProjectId).FirstOrDefaultAsync();
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.ProjectManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId.ToString()))
             {
-                return Task.FromResult(ProjectManagerMarketGroupPermission);
+                return ProjectManagerMarketGroupPermission;
             }
 
-            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserType.MarketGroupManager.ToString()) && claimsPrincipal.HasClaim(AppClaimTypes.MarketGroupManagerOf, marketGroupLongId.ToString()))
+            if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeMarketGroupManager) && claimsPrincipal.HasClaim(AppClaimTypes.MarketGroupManagerOf, marketGroupLongId.ToString()))
             {
-                return Task.FromResult(MarketGroupManagerMarketGroupPermission);
+                return MarketGroupManagerMarketGroupPermission;
             }
 
-            return Task.FromResult(Array.Empty<MarketGroupPermission>());
+            return Array.Empty<MarketGroupPermission>();
         }
     }
 }

--- a/Sig.App.Backend/Services/Permission/PermissionService.cs
+++ b/Sig.App.Backend/Services/Permission/PermissionService.cs
@@ -255,7 +255,7 @@ namespace Sig.App.Backend.Services.Permission
                 var claim = claimsPrincipal.Claims.FirstOrDefault(x => x.Type == AppClaimTypes.ProjectManagerOf);
                 var projectId = Convert.ToInt64(claim?.Value);
                 var project = await db.Projects.FirstOrDefaultAsync(x => x.Id == projectId);
-                if (project.AdministrationSubscriptionsOffPlatform)
+                if (project?.AdministrationSubscriptionsOffPlatform == true)
                 {
                     return ProjectManagerSubscriptionsOffPlatformGlobalPermissions;
                 }
@@ -399,7 +399,7 @@ namespace Sig.App.Backend.Services.Permission
         public async Task<OrganizationPermission[]> GetOrganizationPermissions(ClaimsPrincipal claimsPrincipal, string organizationId)
         {
             var organizationLongId = Id.New<Organization>(organizationId).LongIdentifierForType<Organization>();
-            var organization = await db.Organizations.FirstOrDefaultAsync(x => x.Id == organizationLongId);
+            var organization = await db.Organizations.FirstAsync(x => x.Id == organizationLongId);
             var projectId = organization.ProjectId.ToString();
 
             if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, projectId))
@@ -425,9 +425,9 @@ namespace Sig.App.Backend.Services.Permission
             {
                 beneficiaryLongId = Id.New<OffPlatformBeneficiary>(beneficiaryId).LongIdentifierForType<OffPlatformBeneficiary>();
             }
-            var beneficiary = await db.Beneficiaries.FirstOrDefaultAsync(x => x.Id == beneficiaryLongId);
+            var beneficiary = await db.Beneficiaries.FirstAsync(x => x.Id == beneficiaryLongId);
             var organizationId = beneficiary.OrganizationId.ToString();
-            var project = await db.Organizations.Where(x => x.Id == beneficiary.OrganizationId).Select(x => x.Project).FirstOrDefaultAsync();
+            var project = await db.Organizations.Where(x => x.Id == beneficiary.OrganizationId).Select(x => x.Project).FirstAsync();
 
             if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, project.Id.ToString()))
             {
@@ -455,7 +455,7 @@ namespace Sig.App.Backend.Services.Permission
             var card = await db.Cards
                 .Include(x => x.Beneficiary)
                 .Include(x => x.Project)
-                .FirstOrDefaultAsync(x => x.Id == cardLongId);
+                .FirstAsync(x => x.Id == cardLongId);
 
             if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeProjectManager) && claimsPrincipal.HasClaim(AppClaimTypes.ProjectManagerOf, card.ProjectId.ToString()) && (!card.Project?.BeneficiariesAreAnonymous ?? true))
             {
@@ -464,7 +464,7 @@ namespace Sig.App.Backend.Services.Permission
 
             if (claimsPrincipal.HasClaim(AppClaimTypes.UserType, UserTypeOrganizationManager) && claimsPrincipal.HasClaim(AppClaimTypes.OrganizationManagerOf, card.Beneficiary.OrganizationId.ToString()))
             {
-                var p = db.Projects.First(x => x.Organizations.Any(y => y.Id == Convert.ToInt64(card.Beneficiary.OrganizationId)));
+                var p = await db.Projects.FirstAsync(x => x.Organizations.Any(y => y.Id == Convert.ToInt64(card.Beneficiary.OrganizationId)));
                 if (p.AllowOrganizationsAssignCards)
                 {
                     return OrganizationManagerCardPermissionsWithAssignCard;


### PR DESCRIPTION
2 correctifs:

- Éviter une `NullReferenceException` dans `RequirePermissionAttribute`
- Faire des requêtes `async` dans `PermissionService`, pour tenter d'éviter les erreurs _A second operation was started on this context instance before a previous operation completed._ 
  Si ça ne les règle pas, c'est possible que le problème soit plus en profondeur et qu'un review plus complet de l'utilisation du `DbContext` soit nécessaire.