### PR TITLE
Découpler filter-select et checkbox-group via provide/inject

### DIFF
--- a/Sig.App.Frontend/pinkflamant/components/form/input/checkbox-group.vue
+++ b/Sig.App.Frontend/pinkflamant/components/form/input/checkbox-group.vue
@@ -37,7 +37,6 @@
           :placeholder="effectiveSearchPlaceholder"
           class="pf-select text-[18px] min-h-11 shadow-sm block w-full rounded-md transition-colors duration-200 ease-in-out text-primary-900 border-primary-500 focus:ring-secondary-500 focus:border-secondary-500 placeholder-grey-500 px-10"
           :aria-label="effectiveSearchPlaceholder"
-          data-filter-search
           @mousedown.stop
           @click.stop
           @keydown.stop />
@@ -71,10 +70,12 @@
 </template>
 
 <script>
+import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { commonFieldProps } from "../field/index";
 import FormFieldset from "../fieldset";
+import { useDropdownPanelFocus } from "../../../lib/dropdown-panel-focus";
 import { normalizeForSearch } from "../../../lib/normalize-for-search";
 import ICON_SEARCH from "../../../icons/search.json";
 import ICON_CLOSE from "../../../icons/close.json";
@@ -110,9 +111,15 @@ export default {
     }
   },
   emits: ["input"],
-  setup() {
+  setup(props) {
     const { t } = useI18n();
-    return { t };
+    const searchInput = ref(null);
+
+    if (props.searchable) {
+      useDropdownPanelFocus(() => searchInput.value?.focus());
+    }
+
+    return { t, searchInput };
   },
   data() {
     return {
@@ -162,7 +169,7 @@ export default {
     clearSearch() {
       this.searchValue = "";
       this.$nextTick(() => {
-        this.$refs.searchInput?.focus();
+        this.searchInput?.focus();
       });
     }
   },

--- a/Sig.App.Frontend/pinkflamant/components/form/input/select-searchable.vue
+++ b/Sig.App.Frontend/pinkflamant/components/form/input/select-searchable.vue
@@ -49,7 +49,7 @@
           :aria-errormessage="hasErrorState ? `${id}-error` : null"
           :aria-describedby="description ? `${id}-description` : null"
           @change="onQueryChange"
-          @keydown="onInputKeydown" />
+          @keydown.capture="onInputKeydown" />
         <div class="absolute inset-y-0 right-0 pr-3 flex items-center">
           <button
             v-if="query"

--- a/Sig.App.Frontend/pinkflamant/lib/dropdown-panel-focus.js
+++ b/Sig.App.Frontend/pinkflamant/lib/dropdown-panel-focus.js
@@ -1,0 +1,32 @@
+import { inject, onBeforeUnmount, onMounted, shallowRef, provide, nextTick } from "vue";
+
+export const DropdownPanelFocusKey = Symbol("DropdownPanelFocus");
+
+/** À appeler dans le composant conteneur (ex. filter-select) */
+export function provideDropdownPanelFocus() {
+  const focusHandler = shallowRef(null);
+
+  provide(DropdownPanelFocusKey, {
+    register(handler) {
+      focusHandler.value = handler;
+    },
+    unregister() {
+      focusHandler.value = null;
+    }
+  });
+
+  function requestContentFocus() {
+    nextTick(() => focusHandler.value?.());
+  }
+
+  return { requestContentFocus };
+}
+
+/** À appeler dans un enfant optionnel (ex. checkbox-group searchable) */
+export function useDropdownPanelFocus(focus) {
+  const panelFocus = inject(DropdownPanelFocusKey, null);
+  if (!panelFocus) return;
+
+  onMounted(() => panelFocus.register(focus));
+  onBeforeUnmount(() => panelFocus.unregister());
+}

--- a/Sig.App.Frontend/src/components/ui/filter-select.vue
+++ b/Sig.App.Frontend/src/components/ui/filter-select.vue
@@ -17,8 +17,8 @@
   <div class="relative inline-block group pf-transition-visibility pf-transition-visibility--focus-only">
     <button
       class="pf-button pf-button--outline px-3 min-h-11"
-      @focus="focusSearchInput"
-      @mousedown="focusSearchInput">
+      @focus="requestContentFocus"
+      @mousedown="requestContentFocus">
       {{ props.label }}
       <span
         v-if="props.activeFiltersCount > 0"
@@ -28,7 +28,6 @@
       <PfIcon :icon="ICON_ARROW_BOTTOM" size="xxs" class="ml-2" />
     </button>
     <div
-      ref="contentRef"
       class="text-left absolute z-50 bottom-1 right-0 translate-y-full min-w-64 max-h-60 overflow-auto bg-white rounded-md border rounded-tr-none border-primary-700 px-4 py-3 transition ease-in-out duration-300 pf-transition-visibility__content h-remove-margin">
       <slot></slot>
     </div>
@@ -36,8 +35,9 @@
 </template>
 
 <script setup>
-import { defineProps, ref, nextTick } from "vue";
+import { defineProps } from "vue";
 
+import { provideDropdownPanelFocus } from "@/../pinkflamant/lib/dropdown-panel-focus";
 import ICON_ARROW_BOTTOM from "@/lib/icons/arrow-bottom.json";
 
 const props = defineProps({
@@ -54,11 +54,5 @@ const props = defineProps({
   }
 });
 
-const contentRef = ref(null);
-
-function focusSearchInput() {
-  nextTick(() => {
-    contentRef.value?.querySelector("[data-filter-search]")?.focus();
-  });
-}
+const { requestContentFocus } = provideDropdownPanelFocus();
 </script>

--- a/Sig.App.Frontend/tests/unit/pinkflamant/components/form/input/select-searchable.spec.js
+++ b/Sig.App.Frontend/tests/unit/pinkflamant/components/form/input/select-searchable.spec.js
@@ -84,6 +84,21 @@ describe("select-searchable.vue", () => {
     expect(wrapper.vm.query).toBe("");
   });
 
+  it("emits input when selecting with Enter key", async () => {
+    const wrapper = mountSelectSearchable();
+    const input = wrapper.find('input[role="combobox"]');
+
+    await input.trigger("focus");
+    await input.setValue("école");
+    await flushPromises();
+
+    await input.trigger("keydown", { key: "Enter" });
+    await flushPromises();
+
+    expect(wrapper.emitted("input")).toBeTruthy();
+    expect(wrapper.emitted("input")[0]).toEqual(["org-1"]);
+  });
+
   it("does not emit the first option on blur when a value is already selected", async () => {
     const allGroupsOptions = [
       { label: "Tous les groupes", value: "all-group" },

--- a/Sig.App.Frontend/tests/unit/pinkflamant/lib/dropdown-panel-focus.spec.js
+++ b/Sig.App.Frontend/tests/unit/pinkflamant/lib/dropdown-panel-focus.spec.js
@@ -1,0 +1,99 @@
+import { defineComponent, h } from "vue";
+import { flushPromises, mount } from "@vue/test-utils";
+
+import {
+  provideDropdownPanelFocus,
+  useDropdownPanelFocus
+} from "@/../pinkflamant/lib/dropdown-panel-focus";
+
+const Consumer = defineComponent({
+  name: "DropdownPanelFocusConsumer",
+  props: {
+    onFocus: {
+      type: Function,
+      required: true
+    }
+  },
+  setup(props) {
+    useDropdownPanelFocus(props.onFocus);
+    return () => h("div");
+  }
+});
+
+const Provider = defineComponent({
+  name: "DropdownPanelFocusProvider",
+  setup(_, { slots }) {
+    const { requestContentFocus } = provideDropdownPanelFocus();
+    return () =>
+      h("div", [
+        h("button", { onFocus: requestContentFocus, onMousedown: requestContentFocus }, "open"),
+        slots.default?.()
+      ]);
+  }
+});
+
+describe("dropdown-panel-focus.js", () => {
+  it("calls the registered handler when requestContentFocus is triggered", async () => {
+    const onFocus = jest.fn();
+
+    const wrapper = mount(Provider, {
+      slots: {
+        default: () => h(Consumer, { onFocus })
+      }
+    });
+
+    await wrapper.find("button").trigger("focus");
+    await flushPromises();
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when requestContentFocus is triggered without a registered handler", async () => {
+    const wrapper = mount(Provider);
+
+    await expect(wrapper.find("button").trigger("focus")).resolves.not.toThrow();
+    await flushPromises();
+  });
+
+  it("does not call the handler after the consumer unmounts", async () => {
+    const onFocus = jest.fn();
+    let showConsumer = true;
+
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          const { requestContentFocus } = provideDropdownPanelFocus();
+          return () =>
+            h("div", [
+              h("button", { onFocus: requestContentFocus }, "open"),
+              showConsumer ? h(Consumer, { onFocus }) : null
+            ]);
+        }
+      })
+    );
+
+    await wrapper.find("button").trigger("focus");
+    await flushPromises();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+
+    showConsumer = false;
+    await wrapper.vm.$forceUpdate();
+    await flushPromises();
+
+    onFocus.mockClear();
+    await wrapper.find("button").trigger("focus");
+    await flushPromises();
+
+    expect(onFocus).not.toHaveBeenCalled();
+  });
+
+  it("allows mounting a consumer without a provider", () => {
+    const onFocus = jest.fn();
+
+    expect(() =>
+      mount(Consumer, {
+        props: { onFocus }
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Remplace le hack `querySelector("[data-filter-search]")` dans `filter-select` par un contrat provide/inject explicite (`dropdown-panel-focus.js`).
- `checkbox-group` enregistre son propre handler de focus quand `searchable` est actif ; l'attribut DOM magique `data-filter-search` est supprimé.
- Aucun changement requis dans les sites d'usage (`program-transaction-filters`, `report-filters`, etc.).

## Test plan

- [ ] Ouvrir un filtre searchable (ex. organisations dans l'historique des transactions) : le focus doit aller directement au champ de recherche.
- [ ] Ouvrir un filtre non-searchable (ex. types de transaction carte-cadeau) : le panneau s'ouvre sans erreur.
- [ ] Vérifier que les `checkbox-group` hors `UiFilterSelect` (ex. filtres bénéficiaires) ne sont pas affectés.
- [ ] `npm run test:unit -- --testPathPattern=dropdown-panel-focus` passe.
