### PR TITLE
Adjust the persmission to disable the archive market for a MarketGroup Manager

### DIFF
--- a/Sig.App.Backend/Services/Permission/PermissionService.cs
+++ b/Sig.App.Backend/Services/Permission/PermissionService.cs
@@ -166,8 +166,7 @@ namespace Sig.App.Backend.Services.Permission
         {
             MarketPermission.CreateTransaction,
             MarketPermission.RefundTransaction,
-            MarketPermission.ManageMarket,
-            MarketPermission.ArchiveMarket
+            MarketPermission.ManageMarket
         };
 
         private static readonly OrganizationPermission[] ProjectManagerOrganizationPermission = new[]

--- a/Sig.App.Frontend/src/components/market/market-table.vue
+++ b/Sig.App.Frontend/src/components/market/market-table.vue
@@ -32,19 +32,10 @@
       <td>
         <div class="inline-flex items-center gap-x-2">
           <template v-if="props.canEdit">
-            <PfButtonLink
-              v-if="!slotProps.item.isDisabled"
-              tag="routerLink"
-              btn-style="outline"
-              size="sm"
+            <PfButtonLink v-if="!slotProps.item.isDisabled" tag="routerLink" btn-style="outline" size="sm"
               :label="t('disabled-market')"
               :to="{ name: props.urlNameMarketDisabled, params: { marketId: slotProps.item.id } }" />
-            <PfButtonLink
-              v-else
-              tag="routerLink"
-              btn-style="outline"
-              size="sm"
-              :label="t('enabled-market')"
+            <PfButtonLink v-else tag="routerLink" btn-style="outline" size="sm" :label="t('enabled-market')"
               :to="{ name: props.urlNameMarketEnabled, params: { marketId: slotProps.item.id } }" />
           </template>
           <UiButtonGroup :items="getBtnGroup(slotProps.item)" tooltip-position="left" />
@@ -76,18 +67,19 @@ const props = defineProps({
   urlNameMarketDisabled: { type: String, default: URL_MARKET_DISABLED },
   canEdit: Boolean,
   canDelete: Boolean,
+  canArchive: Boolean,
   orderByMarketName: { type: Boolean, default: false }
 });
 
 const cols = computed(() => {
   return props.canEdit || props.urlNameMarketDelete || props.urlNameMarketArchive
     ? [
-        { label: t("market-name") },
-        {
-          label: t("options"),
-          hasHiddenLabel: true
-        }
-      ]
+      { label: t("market-name") },
+      {
+        label: t("options"),
+        hasHiddenLabel: true
+      }
+    ]
     : [{ label: t("market-name") }];
 });
 
@@ -123,7 +115,7 @@ const getBtnGroup = (market) => [
     icon: ICON_FOLDER,
     label: t("market-archive"),
     route: { name: props.urlNameMarketArchive, params: { marketId: market.id } },
-    if: !market.isArchived && props.urlNameMarketArchive
+    if: !market.isArchived && props.urlNameMarketArchive && props.canArchive
   }
 ];
 

--- a/Sig.App.Frontend/src/views/market/ListMarkets.vue
+++ b/Sig.App.Frontend/src/views/market/ListMarkets.vue
@@ -27,34 +27,24 @@
           <UiTableHeader :title="t('market-count', { count: marketsPagination.items.length })">
             <template #right>
               <div class="flex items-center gap-x-4">
-                <UiFilter
-                  v-model="searchInput"
-                  has-search
-                  :placeholder="t('search-placeholder')"
-                  @resetFilters="resetSearch"
-                  @search="onSearch">
+                <UiFilter v-model="searchInput" has-search :placeholder="t('search-placeholder')"
+                  @resetFilters="resetSearch" @search="onSearch">
                 </UiFilter>
                 <PfButtonLink tag="RouterLink" :to="addMarketRoute" :label="t('add-market')" />
               </div>
             </template>
           </UiTableHeader>
-          <MarketTable
-            can-edit
-            can-delete
-            :markets="marketsPagination.items"
-            :url-name-market-archive="URL_MARKET_ARCHIVE"
-            :url-name-market-delete="URL_MARKET_DELETE"
-            :url-name-market-edit="URL_MARKET_EDIT"
-            :url-name-market-manage-managers="URL_MARKET_MANAGE_MANAGERS" />
-          <UiPagination
-            v-if="marketsPagination && marketsPagination.totalPages > 1"
-            v-model:page="page"
+          <MarketTable can-edit can-archive can-delete :markets="marketsPagination.items"
+            :url-name-market-archive="URL_MARKET_ARCHIVE" :url-name-market-delete="URL_MARKET_DELETE"
+            :url-name-market-edit="URL_MARKET_EDIT" :url-name-market-manage-managers="URL_MARKET_MANAGE_MANAGERS" />
+          <UiPagination v-if="marketsPagination && marketsPagination.totalPages > 1" v-model:page="page"
             :total-pages="marketsPagination.totalPages">
           </UiPagination>
         </template>
 
         <UiEmptyPage v-else>
-          <UiCta :description="t('empty-list')" :primary-btn-label="t('create-market')" :primary-btn-route="addMarketRoute" />
+          <UiCta :description="t('empty-list')" :primary-btn-label="t('create-market')"
+            :primary-btn-route="addMarketRoute" />
         </UiEmptyPage>
       </div>
 

--- a/Sig.App.Frontend/src/views/market/ViewMarkets.vue
+++ b/Sig.App.Frontend/src/views/market/ViewMarkets.vue
@@ -28,51 +28,29 @@
         <UiTableHeader :title="t('market-count', { count: markets.length })">
           <template #right>
             <div class="flex items-center gap-x-4">
-              <UiFilter
-                v-model="searchInput"
-                has-search
-                :has-filters="userType === USER_TYPE_PROJECTMANAGER"
-                :has-active-filters="hasActiveFilters"
-                :active-filters-count="activeFiltersCount"
-                :placeholder="t('search-placeholder')"
-                @resetFilters="resetSearch"
-                @search="onSearch">
-                <PfFormInputCheckboxGroup
-                  v-if="availableMarketGroups.length > 0"
-                  id="market-groups"
-                  is-filter
-                  :value="marketGroups"
-                  :label="t('market-groups')"
-                  :options="availableMarketGroups"
+              <UiFilter v-model="searchInput" has-search :has-filters="userType === USER_TYPE_PROJECTMANAGER"
+                :has-active-filters="hasActiveFilters" :active-filters-count="activeFiltersCount"
+                :placeholder="t('search-placeholder')" @resetFilters="resetSearch" @search="onSearch">
+                <PfFormInputCheckboxGroup v-if="availableMarketGroups.length > 0" id="market-groups" is-filter
+                  :value="marketGroups" :label="t('market-groups')" :options="availableMarketGroups"
                   @input="onMarketGroupsChecked" />
               </UiFilter>
-              <PfButtonLink
-                v-if="userType === USER_TYPE_PROJECTMANAGER || userType === USER_TYPE_MARKETGROUPMANAGER"
-                tag="RouterLink"
-                :to="addMarketRoute"
-                :label="t('add-market')" />
+              <PfButtonLink v-if="userType === USER_TYPE_PROJECTMANAGER || userType === USER_TYPE_MARKETGROUPMANAGER"
+                tag="RouterLink" :to="addMarketRoute" :label="t('add-market')" />
             </div>
           </template>
         </UiTableHeader>
-        <MarketTable
-          v-if="markets.length > 0"
-          can-edit
-          :markets="markets"
-          :url-name-market-archive="URL_MARKET_OVERVIEW_ARCHIVE"
+        <MarketTable v-if="markets.length > 0" can-edit :can-archive="userType !== USER_TYPE_MARKETGROUPMANAGER"
+          :markets="markets" :url-name-market-archive="URL_MARKET_OVERVIEW_ARCHIVE"
           :url-name-market-edit="URL_MARKET_OVERVIEW_EDIT"
           :url-name-market-manage-managers="URL_MARKET_OVERVIEW_MANAGE_MANAGERS"
           :url-name-market-enabled="URL_MARKET_OVERVIEW_ENABLED"
           :url-name-market-disabled="URL_MARKET_OVERVIEW_DISABLED" />
         <UiEmptyPage v-else-if="!loading">
-          <UiCta
-            :description="t('empty-list')"
-            :primary-btn-label="t('reset-search')"
-            primary-btn-is-action
+          <UiCta :description="t('empty-list')" :primary-btn-label="t('reset-search')" primary-btn-is-action
             @onPrimaryBtnClick="resetSearch"></UiCta>
         </UiEmptyPage>
-        <UiPagination
-          v-if="marketsPagination && marketsPagination.totalPages > 1"
-          v-model:page="page"
+        <UiPagination v-if="marketsPagination && marketsPagination.totalPages > 1" v-model:page="page"
           :total-pages="marketsPagination.totalPages">
         </UiPagination>
       </div>


### PR DESCRIPTION
# [[Hotfix] Désactivé l'archivage des commerces pour les gestionnaires de groupe de commerce](https://sigmund-ca.atlassian.net/browse/CRCL-2556)
Temporairement désactiver l’archivage des commerces pour les gestionnaires de groupe de commerce en attendant la fonctionnalité complète de gestion des droits pour les gestionnaires de groupe de commerce.