### PR TITLE
Corriger deux problèmes UI des filtres et de la liste déroulante recherchable

### DIFF
--- a/Sig.App.Frontend/pinkflamant/components/form/input/checkbox-group.vue
+++ b/Sig.App.Frontend/pinkflamant/components/form/input/checkbox-group.vue
@@ -70,12 +70,13 @@
 </template>
 
 <script>
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { commonFieldProps } from "../field/index";
 import FormFieldset from "../fieldset";
 import { useDropdownPanelFocus } from "../../../lib/dropdown-panel-focus";
+import { useFilterReset } from "../../../lib/filter-reset";
 import { normalizeForSearch } from "../../../lib/normalize-for-search";
 import ICON_SEARCH from "../../../icons/search.json";
 import ICON_CLOSE from "../../../icons/close.json";
@@ -114,16 +115,23 @@ export default {
   setup(props) {
     const { t } = useI18n();
     const searchInput = ref(null);
+    const searchValue = ref("");
 
     if (props.searchable) {
       useDropdownPanelFocus(() => searchInput.value?.focus());
+
+      const resetToken = useFilterReset();
+      if (resetToken) {
+        watch(resetToken, () => {
+          searchValue.value = "";
+        });
+      }
     }
 
-    return { t, searchInput };
+    return { t, searchInput, searchValue };
   },
   data() {
     return {
-      searchValue: "",
       leadingIcon: ICON_SEARCH,
       clearIcon: ICON_CLOSE
     };

--- a/Sig.App.Frontend/pinkflamant/components/form/input/select-searchable.vue
+++ b/Sig.App.Frontend/pinkflamant/components/form/input/select-searchable.vue
@@ -30,7 +30,7 @@
       :name="name"
       @update:model-value="onSelect">
       <SlotPropWatcher :value="isOpen" :filter="(value, previousValue) => previousValue && !value" @change="resetQuery" />
-      <div class="relative">
+      <div class="relative" @input="stopNativeLeak" @change="stopNativeLeak">
         <PfIcon
           class="absolute top-1/2 -translate-y-1/2 left-3 flex items-center text-grey-500 pointer-events-none z-10"
           :icon="leadingIcon"
@@ -193,6 +193,12 @@ export default {
     },
     onQueryChange(event) {
       this.query = event.target.value;
+    },
+    stopNativeLeak(event) {
+      // L'input interne affiche le libellé de l'option, pas sa valeur. On empêche
+      // ses événements DOM bruts (input/change) de remonter : la valeur du
+      // composant est exposée uniquement via update:modelValue/input.
+      event.stopPropagation();
     },
     markUserSelection() {
       this.userInitiatedSelection = true;

--- a/Sig.App.Frontend/pinkflamant/lib/filter-reset.js
+++ b/Sig.App.Frontend/pinkflamant/lib/filter-reset.js
@@ -1,0 +1,19 @@
+import { inject, provide, readonly, ref } from "vue";
+
+export const FilterResetKey = Symbol("FilterReset");
+
+export function provideFilterReset() {
+  const resetToken = ref(0);
+
+  provide(FilterResetKey, readonly(resetToken));
+
+  function resetFilters() {
+    resetToken.value++;
+  }
+
+  return { resetFilters };
+}
+
+export function useFilterReset() {
+  return inject(FilterResetKey, null);
+}

--- a/Sig.App.Frontend/src/components/ui/filter.vue
+++ b/Sig.App.Frontend/src/components/ui/filter.vue
@@ -84,6 +84,7 @@ import { defineEmits, defineProps, computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { ASC } from "@/lib/consts/card-sort-order";
+import { provideFilterReset } from "@/../pinkflamant/lib/filter-reset";
 
 import ICON_ARROW_BOTTOM from "@/lib/icons/arrow-bottom.json";
 import ICON_RESET from "@/lib/icons/reset.json";
@@ -130,6 +131,7 @@ const props = defineProps({
 });
 
 const { t } = useI18n();
+const { resetFilters } = provideFilterReset();
 
 const sortLabel = computed(() => {
   return props.sortLabel !== "" ? props.sortLabel : t("sort");
@@ -140,6 +142,7 @@ const iconSortOrder = computed(() => {
 });
 
 function onResetFilters() {
+  resetFilters();
   emit("resetFilters");
 }
 

--- a/Sig.App.Frontend/tests/unit/pinkflamant/components/form/input/select-searchable.spec.js
+++ b/Sig.App.Frontend/tests/unit/pinkflamant/components/form/input/select-searchable.spec.js
@@ -99,6 +99,36 @@ describe("select-searchable.vue", () => {
     expect(wrapper.emitted("input")[0]).toEqual(["org-1"]);
   });
 
+  it("does not let the inner field raw DOM change event bubble out of the component", async () => {
+    const wrapper = mountSelectSearchable({ value: "org-1" });
+    const parentChangeListener = jest.fn();
+    wrapper.element.addEventListener("change", parentChangeListener);
+
+    const input = wrapper.find('input[role="combobox"]');
+    input.element.value = "École primaire";
+    input.element.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushPromises();
+
+    expect(parentChangeListener).not.toHaveBeenCalled();
+
+    wrapper.element.removeEventListener("change", parentChangeListener);
+  });
+
+  it("does not let the inner field raw DOM input event bubble out of the component", async () => {
+    const wrapper = mountSelectSearchable({ value: "org-1" });
+    const parentInputListener = jest.fn();
+    wrapper.element.addEventListener("input", parentInputListener);
+
+    const input = wrapper.find('input[role="combobox"]');
+    input.element.value = "abc";
+    input.element.dispatchEvent(new Event("input", { bubbles: true }));
+    await flushPromises();
+
+    expect(parentInputListener).not.toHaveBeenCalled();
+
+    wrapper.element.removeEventListener("input", parentInputListener);
+  });
+
   it("does not emit the first option on blur when a value is already selected", async () => {
     const allGroupsOptions = [
       { label: "Tous les groupes", value: "all-group" },


### PR DESCRIPTION
# Corrections UI (filtres et select recherchable)

Deux retours QA corrigés, liés aux améliorations de recherche de [CRCL-2039](https://sigmund-ca.atlassian.net/browse/CRCL-2039).

## Changements

### 1. Le champ de recherche des filtres ne se vidait pas à la réinitialisation (CA-12)
- Au clic sur « Réinitialiser », les cases des filtres se vidaient mais le texte saisi dans les champs de recherche restait affiché.
- Ajout d'un petit signal de réinitialisation fourni par `UiFilter` (composable `filter-reset`, via provide/inject) : le champ de recherche des groupes de cases `searchable` se vide lorsqu'on réinitialise les filtres.
- S'applique partout où `UiFilter` permet de réinitialiser (historique des transactions, etc.).
- Comportement conservé : fermer/rouvrir un panneau de filtre ne vide pas la recherche.

### 2. Perte de la sélection au Tab après une sélection au clavier (modal d'ajout de commerce)
- Dans le modal « Ajouter un commerce au programme » : chercher un commerce, le sélectionner avec Entrée, puis presser Tab faisait disparaître la sélection. Avec un clic, le Tab fonctionnait déjà.
- Cause : l'input interne de Headless UI affiche le libellé de l'option (pas sa valeur). Au Tab après une sélection clavier, l'événement `change` DOM natif remontait jusqu'au binding vee-validate (`v-bind=field`) et écrasait le modèle avec le libellé, vidant le champ.
- Correctif au niveau du composant `select-searchable` : ses événements DOM bruts (`input`/`change`) ne remontent plus ; la valeur reste exposée uniquement via `update:modelValue`/`input`.

## Tests
- Ajout de tests unitaires pour `select-searchable` (les événements DOM bruts ne s'échappent plus du composant).
- `npx jest tests/unit/pinkflamant` : 14 tests passent.

## Plan de test QA
- [ ] **Réinitialisation des filtres** : appliquer des filtres avec recherche (ex. historique des transactions), saisir du texte dans un champ de recherche de filtre, cliquer « Réinitialiser » → les filtres ET les champs de recherche sont vidés.
- [ ] **Fermer/rouvrir un panneau** : le texte de recherche n'est PAS vidé (comportement attendu).
- [ ] **Ajout de commerce — clavier** : chercher un commerce, sélectionner avec Entrée, presser Tab → la sélection reste affichée.
- [ ] **Ajout de commerce — souris** : sélectionner avec un clic, presser Tab → la sélection reste affichée (non-régression).
- [ ] **Non-régression** : recherche de groupes/abonnements sur les écrans participant·e·s (sélection clavier et souris) fonctionne toujours.

Made with [Cursor](https://cursor.com)