### PR TITLE
Fix budget allowance checks / Update condition to allow exact budget allowance usage and add new test for this scenario.

### DIFF
--- a/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
+++ b/Sig.App.Backend/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscription.cs
@@ -73,7 +73,7 @@ namespace Sig.App.Backend.Requests.Commands.Mutations.Subscriptions
                     : paymentRemaining;
                 var numberOfPaymentToReceive = Math.Min(cap, paymentRemaining);
 
-                if (subscriptionBeneficiary.BudgetAllowance.AvailableFund + (previousPaymentAmount - newPaymentAmount) * numberOfPaymentToReceive > 0)
+                if (subscriptionBeneficiary.BudgetAllowance.AvailableFund + (previousPaymentAmount - newPaymentAmount) * numberOfPaymentToReceive >= 0)
                 {
                     subscriptionBeneficiary.BudgetAllowance.AvailableFund += (previousPaymentAmount - newPaymentAmount) * numberOfPaymentToReceive;
                     subscriptionBeneficiary.BeneficiaryTypeId = beneficiary.BeneficiaryTypeId.Value;

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/AdjustBeneficiarySubscriptionTest.cs
@@ -402,6 +402,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         [Fact]
         public async Task ThrowsIfNotEnoughBudgetAllowance()
         {
+            beneficiary.BeneficiaryType = beneficiaryType2;
             budgetAllowance1.AvailableFund = 0;
             DbContext.SaveChanges();
 
@@ -416,6 +417,35 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             await F(() => handler.Handle(input, CancellationToken.None))
                 .Should().ThrowAsync<AdjustBeneficiarySubscription.NotEnoughBudgetAllowanceException>();
+        }
+
+        [Fact]
+        public async Task AdjustBeneficiarySubscriptionWithExactBudgetAllowance()
+        {
+            // budgetChange = (50-110)*2 = -120; the envelope holds exactly the required amount
+            beneficiary.BeneficiaryType = beneficiaryType2;
+            budgetAllowance1.AvailableFund = 120;
+            DbContext.SaveChanges();
+
+            var input = new AdjustBeneficiarySubscription.Input()
+            {
+                BeneficiaryId = beneficiary.GetIdentifier(),
+                SubscriptionIds = new List<Id>()
+                {
+                    subscription1.GetIdentifier()
+                }
+            };
+
+            await handler.Handle(input, CancellationToken.None);
+
+            var localBeneficiary = await DbContext.Beneficiaries
+                .Include(x => x.Subscriptions).ThenInclude(x => x.BudgetAllowance)
+                .Include(x => x.Subscriptions).ThenInclude(x => x.BeneficiaryType)
+                .FirstAsync();
+
+            var localSubscriptionBeneficiary = localBeneficiary.Subscriptions.First(x => x.SubscriptionId == subscription1.Id);
+            localSubscriptionBeneficiary.BudgetAllowance.AvailableFund.Should().Be(0);
+            localSubscriptionBeneficiary.BeneficiaryTypeId.Should().Be(beneficiaryType2.Id);
         }
     }
 }

--- a/Sig.App.Frontend/src/views/beneficiary/ManageConflict.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/ManageConflict.vue
@@ -215,7 +215,7 @@ const beneficiarySubscriptionsWithConflict = computed(() => {
       var description = "";
       if (
         previousPaymentAmount < newPaymentAmount &&
-        newPaymentAmount * numberOfPaymentToReceive > budgetAllowanceSubscription.availableFund
+        (newPaymentAmount - previousPaymentAmount) * numberOfPaymentToReceive > budgetAllowanceSubscription.availableFund
       ) {
         description = t("adjustement-amount-not-enought", {
           amount: getMoneyFormat((newPaymentAmount - previousPaymentAmount) * numberOfPaymentToReceive)
@@ -239,7 +239,7 @@ const beneficiarySubscriptionsWithConflict = computed(() => {
         numberOfPaymentToReceive,
         budgetAllowanceAvailableFund: budgetAllowanceSubscription.availableFund,
         disabled:
-          budgetAllowanceSubscription.availableFund + (previousPaymentAmount - newPaymentAmount) * numberOfPaymentToReceive <= 0,
+          budgetAllowanceSubscription.availableFund + (previousPaymentAmount - newPaymentAmount) * numberOfPaymentToReceive < 0,
         previousCategoryName: beneficiarySubscription.beneficiaryType.name,
         previousCategoryAmount: previousPaymentAmount,
         newCategoryName: beneficiary.value.beneficiaryType.name,


### PR DESCRIPTION
# [Pas possible de corriger un conflit de paiement, mais il semble avoir assez d'argent dans l'enveloppe #269](https://sigmund-ca.atlassian.net/browse/CRCL-2565)