### PR TITLE
Des ajustements du texte de la v8.8

### DIFF
--- a/Sig.App.Backend/EmailTemplates/Models/TransactionBeneficiaryReceiptEmail.cs
+++ b/Sig.App.Backend/EmailTemplates/Models/TransactionBeneficiaryReceiptEmail.cs
@@ -13,7 +13,7 @@ namespace Sig.App.Backend.EmailTemplates.Models
         public decimal TotalFund { get; set; }
         public IEnumerable<ProductGroupAvailableFund> ProductGroupAvailableFunds { get; set; }
 
-        public override string Subject => $"Reçu de transaction chez {MarketName} / Transaction receipt at {MarketName}";
+        public override string Subject => $"Reçu de transaction chez {MarketName} / Transaction receipt from {MarketName}";
 
         public TransactionBeneficiaryReceiptEmail(string to, string marketName, string projectName, string projectUrl, decimal amount, decimal totalFund, IEnumerable<ProductGroupAvailableFund> productGroupAvailableFunds, string beneficiaryId) : base(to)
         {

--- a/Sig.App.Backend/EmailTemplates/Models/TransactionRefundBeneficiaryReceiptEmail.cs
+++ b/Sig.App.Backend/EmailTemplates/Models/TransactionRefundBeneficiaryReceiptEmail.cs
@@ -13,7 +13,7 @@ namespace Sig.App.Backend.EmailTemplates.Models
         public decimal TotalFund { get; set; }
         public IEnumerable<RefundProductGroupAvailableFund> ProductGroupAvailableFunds { get; set; }
 
-        public override string Subject => $"Reçu de rembourssement chez {MarketName} / Reimbursement receipt from {MarketName}";
+        public override string Subject => $"Reçu de remboursement chez {MarketName} / Reimbursement receipt from {MarketName}";
 
         public TransactionRefundBeneficiaryReceiptEmail(string to, string marketName, string projectName, string projectUrl, decimal amount, decimal totalFund, IEnumerable<RefundProductGroupAvailableFund> productGroupAvailableFunds, string beneficiaryId) : base(to)
         {

--- a/Sig.App.Backend/EmailTemplates/TransactionBeneficiaryReceipt.cshtml
+++ b/Sig.App.Backend/EmailTemplates/TransactionBeneficiaryReceipt.cshtml
@@ -4,17 +4,30 @@
 @{ Layout = "_EmailLayout.cshtml"; }
 
 <p>
-    Reçu de transaction
+    <i><b>English text below</b></i>
 </p>
 <p>
-    <b>Un paiement de @MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.FR) a été complété entre vous et le commerce @Model.MarketName.</b><br />
-    <b>Votre solde est maintenant @MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.FR), réparti dans les groupes de produits suivants:</b>
+    Ceci est un message automatique. Merci de ne pas y répondre.<br />
+    Pour des informations concernant votre carte, veuillez contacter l'organisme qui vous l'a fournie.<br />
+    Pour toute question concernant votre achat, veuillez contacter directement le vendeur.
+</p>
+<p>
+    This is an automated message. Please do not respond.<br />
+    For questions about your card, please contact the organization the provided it.<br />
+    For inquiries about your purchase, please contact the seller directly.
+</p>
+<p>
+    <b>Reçu de transaction</b>
+</p>
+<p>
+    Un paiement de <b>@MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.FR)</b> a été complété entre vous et le commerce @Model.MarketName.<br />
+    Votre solde est maintenant <b>@MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.FR)</b>, réparti dans les groupes de produits suivants :
 </p>
 <p>
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            <b>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)</b><br />
+            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)<br />
         }
     }
 </p>
@@ -22,27 +35,27 @@
     if (Model.ProjectUrl != "" && Model.ProjectUrl != null)
     {
         <p>
-            En savoir plus sur le programme:<br />
+            En savoir plus sur le programme :
             <a clicktracking="off" href="@Model.ProjectUrl">@Model.ProjectName</a>
         </p>
     }
 }
 <p>
-    Vous recevez ce courriel parce que vous êtes inscrit à notre plateforme. Si vous ne souhaitez plus recevoir de courriels, vous pouvez vous désabonner en cliquant ici : <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Se désabonner</a>
+    Vous recevez ce courriel parce que vous êtes inscrit·e à une carte qui utilise la plateforme de paiement Tomat. Si vous ne souhaitez plus recevoir ces courriels, vous pouvez vous désabonner en cliquant ici : <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Se désabonner</a>
 </p>
 <br />
 <p>
-    Transaction receipt
+    <b>Transaction receipt</b>
 </p>
 <p>
-    <b>A payment of @MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.EN) has been completed between you and @Model.MarketName.</b><br />
-    <b>Your balance is now @MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.EN), divided into the following product groups:</b>
+    A payment of <b>@MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.EN)</b> has been completed between you and @Model.MarketName.<br />
+    Your balance is now <b>@MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.EN)</b>, divided into the following product groups:
 </p>
 <p>
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            <b>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)</b><br />
+            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)<br />
         }
     }
 </p>
@@ -50,11 +63,11 @@
     if (Model.ProjectUrl != "" && Model.ProjectUrl != null)
     {
         <p>
-            Learn more about the program:<br />
+            Learn more about the program:
             <a clicktracking="off" href="@Model.ProjectUrl">@Model.ProjectName</a>
         </p>
     }
 }
 <p>
-    You are receiving this email because you are registered on our platform. If you no longer wish to receive emails, you can unsubscribe by clicking here : <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Unsubscribe</a>
+    You are receiving this email because you are registered to a card that uses the Tomat payment platform. If you no longer wish to receive these emails, you can unsubscribe by clicking here: <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Unsubscribe</a>
 </p>

--- a/Sig.App.Backend/EmailTemplates/TransactionBeneficiaryReceipt.cshtml
+++ b/Sig.App.Backend/EmailTemplates/TransactionBeneficiaryReceipt.cshtml
@@ -27,7 +27,7 @@
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)<br />
+            <span>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)</span><br />
         }
     }
 </p>
@@ -55,7 +55,7 @@
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)<br />
+            <span>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)</span><br />
         }
     }
 </p>

--- a/Sig.App.Backend/EmailTemplates/TransactionRefundBeneficiaryReceipt.cshtml
+++ b/Sig.App.Backend/EmailTemplates/TransactionRefundBeneficiaryReceipt.cshtml
@@ -4,17 +4,30 @@
 @{ Layout = "_EmailLayout.cshtml"; }
 
 <p>
-    Reçu de remboursement
+    <i><b>English text below</b></i>
 </p>
 <p>
-    <b>Un remboursement de @MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.FR) a été complété entre vous et le commerce @Model.MarketName.</b><br />
-    <b>Votre solde est maintenant @MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.FR), réparti dans les groupes de produits suivants:</b>
+    Ceci est un message automatique. Merci de ne pas y répondre.<br />
+    Pour des informations concernant votre carte, veuillez contacter l'organisme qui vous l'a fournie.<br />
+    Pour toute question concernant votre achat, veuillez contacter directement le vendeur.
+</p>
+<p>
+    This is an automated message. Please do not respond.<br />
+    For questions about your card, please contact the organization the provided it.<br />
+    For inquiries about your purchase, please contact the seller directly.
+</p>
+<p>
+    <b>Reçu de remboursement</b>
+</p>
+<p>
+    Un remboursement de <b>@MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.FR)</b> a été complété entre vous et le commerce <b>@Model.MarketName.<br />
+    Votre solde est maintenant @MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.FR)</b>, réparti dans les groupes de produits suivants :
 </p>
 <p>
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            <b>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)</b><br />
+            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)<br />
         }
     }
 </p>
@@ -22,27 +35,27 @@
     if (Model.ProjectUrl != "" && Model.ProjectUrl != null)
     {
         <p>
-            En savoir plus sur le programme:<br />
+            En savoir plus sur le programme :
             <a clicktracking="off" href="@Model.ProjectUrl">@Model.ProjectName</a>
         </p>
     }
 }
 <p>
-    Vous recevez ce courriel parce que vous êtes inscrit à notre plateforme. Si vous ne souhaitez plus recevoir de courriels, vous pouvez vous désabonner en cliquant ici : <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Se désabonner</a>
+    Vous recevez ce courriel parce que vous êtes inscrit·e à une carte qui utilise la plateforme de paiement Tomat. Si vous ne souhaitez plus recevoir ces courriels, vous pouvez vous désabonner en cliquant ici : <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Se désabonner</a>
 </p>
 <br />
 <p>
-    Transaction receipt
+    <b>Transaction receipt</b>
 </p>
 <p>
-    <b>A refund of @MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.EN) has been completed between you and @Model.MarketName.</b><br />
-    <b>Your balance is now @MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.EN), divided into the following product groups:</b>
+    A refund of <b>@MoneyHelper.GetMoneyFormat(Model.Amount, MoneyHelper.EN)</b> has been completed between you and @Model.MarketName.<br />
+    Your balance is now <b>@MoneyHelper.GetMoneyFormat(Model.TotalFund, MoneyHelper.EN)</b>, divided into the following product groups:
 </p>
 <p>
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            <b>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)</b><br />
+            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)<br />
         }
     }
 </p>
@@ -50,11 +63,11 @@
     if (Model.ProjectUrl != "" && Model.ProjectUrl != null)
     {
         <p>
-            Learn more about the program:<br />
+            Learn more about the program:
             <a clicktracking="off" href="@Model.ProjectUrl">@Model.ProjectName</a>
         </p>
     }
 }
 <p>
-    You are receiving this email because you are registered on our platform. If you no longer wish to receive emails, you can unsubscribe by clicking here : <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Unsubscribe</a>
+    You are receiving this email because you are registered to a card that uses the Tomat payment platform. If you no longer wish to receive these emails, you can unsubscribe by clicking here: <a href="@Model.BaseUrl/@UrlHelper.UnsubscribeFromTransactionReceipt(Model.BeneficiaryId)">Unsubscribe</a>
 </p>

--- a/Sig.App.Backend/EmailTemplates/TransactionRefundBeneficiaryReceipt.cshtml
+++ b/Sig.App.Backend/EmailTemplates/TransactionRefundBeneficiaryReceipt.cshtml
@@ -27,7 +27,7 @@
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)<br />
+            <span>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.FR)</span><br />
         }
     }
 </p>
@@ -55,7 +55,7 @@
     @{
         foreach (var item in Model.ProductGroupAvailableFunds)
         {
-            @item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)<br />
+            <span>@item.Name - @MoneyHelper.GetMoneyFormat(item.Fund, MoneyHelper.EN)</span><br />
         }
     }
 </p>

--- a/Sig.App.Backend/EmailTemplates/_EmailLayout.cshtml
+++ b/Sig.App.Backend/EmailTemplates/_EmailLayout.cshtml
@@ -6,5 +6,15 @@
 </head>
 <body>
 <div>@RenderBody()</div>
+
+<p>
+    <br />
+    Envoyé depuis la plateforme Tomat par / Sent from the Tomat platform by:<br />
+    Collectif Récolte<br />
+    4510 rue Cartier, suite 201, Montréal, QC, H2H 1W8<br />
+    <a clicktracking="off" href="https://info.allotomat.com/">info.allotomat.com</a> —
+    <a clicktracking="off" href="https://recolte.ca/">recolte.ca</a>
+</p>
+
 </body>
 </html>

--- a/Sig.App.Frontend/src/components/beneficiaries/beneficiary-actions.vue
+++ b/Sig.App.Frontend/src/components/beneficiaries/beneficiary-actions.vue
@@ -15,7 +15,7 @@
       "beneficiary-delete-disabled": "You can't delete a participant with a card assigned",
       "beneficiary-delete-disabled-anonymous": "You can't delete an anonymous participant",
       "beneficiary-disable-card": "Deactivate card",
-      "beneficiary-enable-card": "Re-enable card",
+      "beneficiary-enable-card": "Reactivate card",
       "beneficiary-payment-conflict": "Fix conflicts",
       "beneficiary-payment-conflict-disabled": "The participant doesn't have a payment conflict",
       "beneficiary-payment-conflict-all-group-selected": "You can't fix a conflict if the \"All Groups\" option is selected",

--- a/Sig.App.Frontend/src/components/beneficiaries/beneficiary-actions.vue
+++ b/Sig.App.Frontend/src/components/beneficiaries/beneficiary-actions.vue
@@ -22,7 +22,7 @@
       "beneficiary-assign-subscription": "Assign subscription",
       "beneficiary-assign-subscription-disabled": "You can't assign a subscription if the \"All Groups\" option is selected",
       "beneficiary-create-transaction": "Create transaction",
-      "beneficiary-create-transaction-no-market": "You can't create a transaction if the group doesn't have a market",
+      "beneficiary-create-transaction-no-market": "You can't create a transaction if the group doesn't have a merchant",
       "beneficiary-create-transaction-no-card": "You can't create a transaction if the participant doesn't have a card",
       "beneficiary-create-transaction-card-disabled": "You can't create a transaction if the participant's card is deactivated",
       "beneficiary-create-transaction-all-group": "You can't create a transaction if the \"All Groups\" option is selected",

--- a/Sig.App.Frontend/src/components/market/market-table.vue
+++ b/Sig.App.Frontend/src/components/market/market-table.vue
@@ -7,8 +7,8 @@
           "market-edit-managers": "Edit managers",
           "market-name": "Name",
           "options": "Options",
-          "disabled-market": "Disable",
-          "enabled-market": "Enable"
+          "disabled-market": "Deactivate",
+          "enabled-market": "Reactivate"
       },
       "fr": {
           "edit-market": "Modifier",

--- a/Sig.App.Frontend/src/views/account/Login.vue
+++ b/Sig.App.Frontend/src/views/account/Login.vue
@@ -18,7 +18,7 @@
     "about": "About Tomat",
     "about-link": "https://info.allotomat.com/about/",
     "form-title": "Welcome to Tomat",
-    "form-subtitle": "Tomat accounts are only for program operators and merchants. If you have a card, you may click the "Check my card balance button" without logging in."
+    "form-subtitle": "Tomat accounts are only for program operators and merchants. If you have a card, you may click the \"Check my card balance\" button without logging in."
 	},
 	"fr": {
 		"forgot-password": "Mot de passe oublié ?",
@@ -45,40 +45,23 @@
 
 <template>
   <div class="flex flex-col bg-primary-100 min-h-[100dvh]">
-    <div class="absolute after:absolute sm:relative after:inset-0 after:bg-primary-900/50 w-full h-[45dvh] min-h-[240px] dark">
+    <div
+      class="absolute after:absolute sm:relative after:inset-0 after:bg-primary-900/50 w-full h-[45dvh] min-h-[240px] dark">
       <img class="absolute inset-0 w-full h-full object-cover" :src="require('@/assets/img/bg-login.jpg')" alt="" />
       <LangSwitch class="sm:hidden top-6 right-section z-10 absolute" />
       <nav class="hidden sm:block z-10 relative px-section py-6">
         <ul class="flex items-center gap-x-4 md:gap-x-8 leading-none">
           <li>
-            <PfButtonLink
-              class="no-underline"
-              btn-style="link"
-              has-icon-left
-              :icon="ICON_INFO"
-              :href="t('about-link')"
-              :label="t('about')"
-              target="_blank" />
+            <PfButtonLink class="no-underline" btn-style="link" has-icon-left :icon="ICON_INFO" :href="t('about-link')"
+              :label="t('about')" target="_blank" />
           </li>
           <li>
-            <PfButtonLink
-              class="no-underline"
-              btn-style="link"
-              has-icon-left
-              :icon="ICON_SUPPORT"
-              :href="t('support-link')"
-              :label="t('support')"
-              target="_blank" />
+            <PfButtonLink class="no-underline" btn-style="link" has-icon-left :icon="ICON_SUPPORT"
+              :href="t('support-link')" :label="t('support')" target="_blank" />
           </li>
           <li class="ml-auto">
-            <PfButtonLink
-              class="rounded-full"
-              tag="RouterLink"
-              btn-style="secondary"
-              has-icon-left
-              :icon="ICON_HAND_CARD"
-              :to="{ name: URL_CARD_CHECK }"
-              :label="t('check-my-balance')" />
+            <PfButtonLink class="rounded-full" tag="RouterLink" btn-style="secondary" has-icon-left
+              :icon="ICON_HAND_CARD" :to="{ name: URL_CARD_CHECK }" :label="t('check-my-balance')" />
           </li>
           <li>
             <LangSwitch />
@@ -92,18 +75,13 @@
       <div>
         <h1 class="mt-0 sm:mt-14">
           <span class="sr-only">{{ t("title") }}</span>
-          <img
-            class="sm:-left-[6.5rem] md:-left-32 relative mx-auto sm:mx-0 h-16 sm:h-20 md:h-24"
-            :src="require('@/assets/logo/logo-white.svg')"
-            :alt="t('logo')" />
+          <img class="sm:-left-[6.5rem] md:-left-32 relative mx-auto sm:mx-0 h-16 sm:h-20 md:h-24"
+            :src="require('@/assets/logo/logo-white.svg')" :alt="t('logo')" />
         </h1>
         <p class="hidden sm:block mt-14 font-semibold text-h2">{{ t("subtitle") }}</p>
       </div>
       <div class="bg-white sm:mt-5 p-8 md:p-12 pb-5 md:pb-5 rounded-2xl sm:w-5/12 sm:min-w-96">
-        <Form
-          v-slot="{ isSubmitting }"
-          :validation-schema="validationSchema"
-          :initial-values="initialFormValues"
+        <Form v-slot="{ isSubmitting }" :validation-schema="validationSchema" :initial-values="initialFormValues"
           @submit="onSubmit">
           <PfFormSection>
             <div class="sm:mb-4">
@@ -113,34 +91,26 @@
               <p id="connexionFormDesc" class="mt-1 mb-0 text-p2 text-primary-700">{{ t("form-subtitle") }}</p>
             </div>
             <Field v-slot="{ field, errors }" name="email">
-              <PfFormInputText
-                id="email"
-                v-bind="field"
-                :label="t('username')"
-                :errors="errors"
-                input-type="email"></PfFormInputText>
+              <PfFormInputText id="email" v-bind="field" :label="t('username')" :errors="errors" input-type="email">
+              </PfFormInputText>
             </Field>
 
             <Field v-slot="{ field, errors }" name="password">
-              <PfFormInputText
-                id="password"
-                v-bind="field"
-                :label="t('password')"
-                :errors="errors"
+              <PfFormInputText id="password" v-bind="field" :label="t('password')" :errors="errors"
                 input-type="password"></PfFormInputText>
             </Field>
           </PfFormSection>
 
           <div class="flex justify-between items-center mt-8 pt-5 border-grey-300 border-t">
-            <RouterLink
-              class="relative text-p3 h-extend-cursor-area pf-button pf-button--link"
+            <RouterLink class="relative text-p3 h-extend-cursor-area pf-button pf-button--link"
               :to="{ name: URL_ACCOUNT_FORGOT_PASSWORD }">
               {{ t("forgot-password") }}
             </RouterLink>
 
             <div>
               <div class="inline-block relative">
-                <PfButtonAction btn-style="primary" class="px-8" type="submit" :label="t('login')" :is-disabled="isSubmitting" />
+                <PfButtonAction btn-style="primary" class="px-8" type="submit" :label="t('login')"
+                  :is-disabled="isSubmitting" />
                 <div class="top-1/2 right-1 absolute -translate-y-1/2">
                   <PfSpinner v-if="isSubmitting" text-color-class="text-white" :loading-label="t('loading')" is-small />
                 </div>
@@ -154,34 +124,16 @@
     <nav class="sm:hidden mb-6 px-section">
       <ul class="mb-0 text-center">
         <li class="mb-5">
-          <PfButtonLink
-            class="rounded-full"
-            tag="RouterLink"
-            btn-style="secondary"
-            has-icon-left
-            :icon="ICON_HAND_CARD"
-            :to="{ name: URL_CARD_CHECK }"
-            :label="t('check-my-balance')" />
+          <PfButtonLink class="rounded-full" tag="RouterLink" btn-style="secondary" has-icon-left :icon="ICON_HAND_CARD"
+            :to="{ name: URL_CARD_CHECK }" :label="t('check-my-balance')" />
         </li>
         <li class="mb-4">
-          <PfButtonLink
-            class="no-underline"
-            btn-style="link"
-            has-icon-left
-            :icon="ICON_INFO"
-            :href="t('about-link')"
-            :label="t('about')"
-            target="_blank" />
+          <PfButtonLink class="no-underline" btn-style="link" has-icon-left :icon="ICON_INFO" :href="t('about-link')"
+            :label="t('about')" target="_blank" />
         </li>
         <li>
-          <PfButtonLink
-            class="no-underline"
-            btn-style="link"
-            has-icon-left
-            :icon="ICON_SUPPORT"
-            :href="t('support-link')"
-            :label="t('support')"
-            target="_blank" />
+          <PfButtonLink class="no-underline" btn-style="link" has-icon-left :icon="ICON_SUPPORT"
+            :href="t('support-link')" :label="t('support')" target="_blank" />
         </li>
       </ul>
     </nav>

--- a/Sig.App.Frontend/src/views/account/Login.vue
+++ b/Sig.App.Frontend/src/views/account/Login.vue
@@ -18,7 +18,7 @@
     "about": "About Tomat",
     "about-link": "https://info.allotomat.com/about/",
     "form-title": "Welcome to Tomat",
-    "form-subtitle": "Enter your login credentials"
+    "form-subtitle": "Tomat accounts are only for program operators and merchants. If you have a card, you may click the "Check my card balance button" without logging in."
 	},
 	"fr": {
 		"forgot-password": "Mot de passe oublié ?",
@@ -38,17 +38,17 @@
     "about": "À propos de Tomat",
     "about-link": "https://info.allotomat.com/a-propos/",
     "form-title": "Bienvenue sur Tomat",
-    "form-subtitle": "Entrez vos identifiants de connexion"
+    "form-subtitle": "Les comptes Tomat sont réservés aux gestionnaires de programmes et aux marchands. Si vous avez une carte, vous pouvez appuyer sur le bouton «\xa0Vérification du solde de ma carte\xa0» sans vous connecter."
 	}
 }
 </i18n>
 
 <template>
-  <div class="bg-primary-100 flex flex-col min-h-[100dvh]">
-    <div class="dark absolute sm:relative w-full h-[45dvh] min-h-[240px] after:absolute after:inset-0 after:bg-primary-900/50">
-      <img class="absolute inset-0 h-full w-full object-cover" :src="require('@/assets/img/bg-login.jpg')" alt="" />
-      <LangSwitch class="absolute top-6 right-section z-10 sm:hidden" />
-      <nav class="hidden relative z-10 sm:block px-section py-6">
+  <div class="flex flex-col bg-primary-100 min-h-[100dvh]">
+    <div class="absolute after:absolute sm:relative after:inset-0 after:bg-primary-900/50 w-full h-[45dvh] min-h-[240px] dark">
+      <img class="absolute inset-0 w-full h-full object-cover" :src="require('@/assets/img/bg-login.jpg')" alt="" />
+      <LangSwitch class="sm:hidden top-6 right-section z-10 absolute" />
+      <nav class="hidden sm:block z-10 relative px-section py-6">
         <ul class="flex items-center gap-x-4 md:gap-x-8 leading-none">
           <li>
             <PfButtonLink
@@ -88,18 +88,18 @@
     </div>
 
     <div
-      class="relative px-section pt-16 pb-8 w-xl max-w-full mx-auto sm:flex flex-row-reverse justify-end gap-x-16 md:gap-x-20 sm:-mt-56 md:-mt-60">
+      class="relative sm:flex flex-row-reverse justify-end gap-x-16 md:gap-x-20 mx-auto sm:-mt-56 md:-mt-60 px-section pt-16 pb-8 w-xl max-w-full">
       <div>
         <h1 class="mt-0 sm:mt-14">
           <span class="sr-only">{{ t("title") }}</span>
           <img
-            class="h-16 sm:h-20 md:h-24 mx-auto sm:mx-0 relative sm:-left-[6.5rem] md:-left-32"
+            class="sm:-left-[6.5rem] md:-left-32 relative mx-auto sm:mx-0 h-16 sm:h-20 md:h-24"
             :src="require('@/assets/logo/logo-white.svg')"
             :alt="t('logo')" />
         </h1>
-        <p class="hidden sm:block text-h2 font-semibold mt-14">{{ t("subtitle") }}</p>
+        <p class="hidden sm:block mt-14 font-semibold text-h2">{{ t("subtitle") }}</p>
       </div>
-      <div class="bg-white rounded-2xl p-8 sm:mt-5 md:p-12 pb-5 md:pb-5 sm:min-w-96 sm:w-5/12">
+      <div class="bg-white sm:mt-5 p-8 md:p-12 pb-5 md:pb-5 rounded-2xl sm:w-5/12 sm:min-w-96">
         <Form
           v-slot="{ isSubmitting }"
           :validation-schema="validationSchema"
@@ -107,7 +107,7 @@
           @submit="onSubmit">
           <PfFormSection>
             <div class="sm:mb-4">
-              <h2 class="text-h1 leading-6 font-bold text-primary-900 mt-0 mb-3" aria-describedby="connexionFormDesc">
+              <h2 class="mt-0 mb-3 font-bold text-h1 text-primary-900 leading-6" aria-describedby="connexionFormDesc">
                 {{ t("form-title") }}
               </h2>
               <p id="connexionFormDesc" class="mt-1 mb-0 text-p2 text-primary-700">{{ t("form-subtitle") }}</p>
@@ -131,9 +131,9 @@
             </Field>
           </PfFormSection>
 
-          <div class="flex items-center justify-between border-t border-grey-300 pt-5 mt-8">
+          <div class="flex justify-between items-center mt-8 pt-5 border-grey-300 border-t">
             <RouterLink
-              class="relative h-extend-cursor-area pf-button pf-button--link text-p3"
+              class="relative text-p3 h-extend-cursor-area pf-button pf-button--link"
               :to="{ name: URL_ACCOUNT_FORGOT_PASSWORD }">
               {{ t("forgot-password") }}
             </RouterLink>
@@ -141,7 +141,7 @@
             <div>
               <div class="inline-block relative">
                 <PfButtonAction btn-style="primary" class="px-8" type="submit" :label="t('login')" :is-disabled="isSubmitting" />
-                <div class="absolute -translate-y-1/2 top-1/2 right-1">
+                <div class="top-1/2 right-1 absolute -translate-y-1/2">
                   <PfSpinner v-if="isSubmitting" text-color-class="text-white" :loading-label="t('loading')" is-small />
                 </div>
               </div>
@@ -151,7 +151,7 @@
       </div>
     </div>
 
-    <nav class="sm:hidden px-section mb-6">
+    <nav class="sm:hidden mb-6 px-section">
       <ul class="mb-0 text-center">
         <li class="mb-5">
           <PfButtonLink

--- a/Sig.App.Frontend/src/views/beneficiary/TransferFund.vue
+++ b/Sig.App.Frontend/src/views/beneficiary/TransferFund.vue
@@ -2,12 +2,12 @@
 {
   "en": {
     "title": "Transfer Funds",
-    "add-subscription-payment-title": "Subscription payment per rules",
-    "add-subscription-payment-desc": "Funds will be added to the participant's card according to the subscription settings.",
-    "add-subscription-payment": "Subscription payment per rules",
-    "manually-add-funds-title": "Manually add funds",
-    "manually-add-funds-desc": "Add a specific amount to the participant's card with a chosen expiration date.",
-    "manually-add-funds": "Manually add funds",
+    "add-subscription-payment-title": "Replicate a scheduled payment",
+    "add-subscription-payment-desc": "Add the proper funds to the participant's card according to the subscription settings.",
+    "add-subscription-payment": "Replicate a scheduled payment",
+    "manually-add-funds-title": "Transfer a custom amount",
+    "manually-add-funds-desc": "Add a custom amount to the participant's card with a chosen expiration date.",
+    "manually-add-funds": "Transfer a custom amount",
     "add-gift-card-funds-title": "Add gift card funds to the card",
     "add-gift-card-funds-desc": "Add a gift card amount to the participant's card without an expiration date.",
     "add-gift-card-funds": "Add gift card funds to the card",
@@ -16,14 +16,14 @@
   },
   "fr": {
     "title": "Transférer des fonds",
-    "add-subscription-payment-title": "Versement selon les règles de l'abonnement",
-    "add-subscription-payment-desc": "Selon les paramètres de l'abonnement, les fonds seront ajoutés à la carte du ou de la participant·e.",
-    "add-subscription-payment": "Versement selon les règles de l'abonnement",
+    "add-subscription-payment-title": "Reproduire un versement automatisé",
+    "add-subscription-payment-desc": "Ajoutez les fonds appropriés sur la carte, conformément aux paramètres de l'abonnement.",
+    "add-subscription-payment": "Reproduire un versement automatisé",
     "manually-add-funds-title": "Versement sur mesure",
-    "manually-add-funds-desc": "Ajouter un montant sur la carte du ou de la participant·e avec une date d'expiration au choix.",
+    "manually-add-funds-desc": "Ajouter un montant customisé sur la carte avec une date d'expiration au choix.",
     "manually-add-funds": "Versement sur mesure",
     "add-gift-card-funds-title": "Ajouter des fonds carte-cadeau",
-    "add-gift-card-funds-desc": "Ajouter un montant carte-cadeau à la carte du ou de la participant·e sans date d'expiration.",
+    "add-gift-card-funds-desc": "Ajouter un montant carte-cadeau à la carte sans date d'expiration.",
     "add-gift-card-funds": "Ajouter des fonds carte-cadeau",
     "add-subscription-payment-tooltip": "Aucun versement possible selon les règles de l'abonnement",
     "manually-add-funds-tooltip": "Aucun abonnement actif trouvé"
@@ -36,7 +36,7 @@
     <div class="flex flex-col gap-6">
       <div class="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-6">
         <UiCallout class="min-w-0" :variant="CALLOUT_INFO">
-          <p class="font-medium mb-1 m-0">{{ t("add-subscription-payment-title") }}</p>
+          <!-- <p class="font-medium mb-1 m-0">{{ t("add-subscription-payment-title") }}</p> -->
           <p class="m-0">{{ t("add-subscription-payment-desc") }}</p>
         </UiCallout>
         <PfTooltip :hide-tooltip="canAddSubscriptionPayment" :label="!canAddSubscriptionPayment ? t('add-subscription-payment-tooltip') : undefined">
@@ -53,7 +53,7 @@
       </div>
       <div class="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-6">
         <UiCallout class="min-w-0" :variant="CALLOUT_INFO">
-          <p class="font-medium mb-1 m-0">{{ t("manually-add-funds-title") }}</p>
+          <!-- <p class="font-medium mb-1 m-0">{{ t("manually-add-funds-title") }}</p> -->
           <p class="m-0">{{ t("manually-add-funds-desc") }}</p>
         </UiCallout>
         <PfTooltip
@@ -74,7 +74,7 @@
         v-if="userType === USER_TYPE_PROJECTMANAGER"
         class="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-6">
         <UiCallout class="min-w-0" :variant="CALLOUT_INFO">
-          <p class="font-medium mb-1 m-0">{{ t("add-gift-card-funds-title") }}</p>
+          <!-- <p class="font-medium mb-1 m-0">{{ t("add-gift-card-funds-title") }}</p> -->
           <p class="m-0">{{ t("add-gift-card-funds-desc") }}</p>
         </UiCallout>
         <PfButtonLink

--- a/Sig.App.Frontend/src/views/card/EnableCard.vue
+++ b/Sig.App.Frontend/src/views/card/EnableCard.vue
@@ -5,10 +5,10 @@
     "delete-text-card-number-error": "Text must match card number",
 		"delete-text-beneficiary-name-label": "Type the participant's full name to confirm",
     "delete-text-card-number-label": "Type the card number to confirm",
-		"description": "Warning! If you continue, the card will be enabled and the participant will be able to use the card.",
-		"title": "Enable Card - {beneficiaryName}",
-		"enable-btn-label": "Enable",
-		"enable-card-success-notification": "The card has been successfully enabled."
+		"description": "Warning! If you continue, the card will be reactivated and the participant will be able to use the card.",
+		"title": "Reactivate Card - {beneficiaryName}",
+		"enable-btn-label": "Reactivate",
+		"enable-card-success-notification": "The card has been successfully reactivated."
 	},
 	"fr": {
 		"delete-text-beneficiary-name-error": "Le texte doit correspondre au prénom et au nom de famille du ou de la participant·e",

--- a/Sig.App.Frontend/src/views/card/ManageCards.vue
+++ b/Sig.App.Frontend/src/views/card/ManageCards.vue
@@ -18,7 +18,7 @@
     "card-unassigned": "Unassigned",
     "search-placeholder": "Search by ID or card number",
     "beneficiary-disable-card": "Deactivate card",
-    "beneficiary-enable-card": "Enable card",
+    "beneficiary-enable-card": "Reactivate card",
     "card-disabled-status": "Card status",
     "card-is-disabled": "Temporarily deactivated",
     "card-is-enabled": "Not deactivated",

--- a/Sig.App.Frontend/src/views/card/ManageGiftCards.vue
+++ b/Sig.App.Frontend/src/views/card/ManageGiftCards.vue
@@ -19,7 +19,7 @@
       "card-unassigned": "Unassigned",
       "search-placeholder": "Search by ID or card number",
       "beneficiary-disable-card": "Deactivate card",
-      "beneficiary-enable-card": "Enable card",
+      "beneficiary-enable-card": "Reactivate card",
       "card-disabled-status": "Card status",
       "card-is-disabled": "Temporarily deactivated",
       "card-is-enabled": "Not deactivated",

--- a/Sig.App.Frontend/src/views/market/EnabledMarket.vue
+++ b/Sig.App.Frontend/src/views/market/EnabledMarket.vue
@@ -1,18 +1,18 @@
 <i18n>
 {
 	"en": {
-		"enabled-market-success-notification": "The merchant {marketName} has been successfully enabled.",
+		"enabled-market-success-notification": "The merchant {marketName} has been successfully reactivated.",
 		"enabled-text-error": "The text must match the name of the merchant.",
 		"enabled-text-label": "Type the name of the merchant to confirm",
-		"description": "Warning! If you continue, the merchant will be enabled and will be able to process transactions.",
-		"title": "Enabled - {marketName}",
-    "enabled-btn-label": "Enabled"
+		"description": "Warning! If you continue, the merchant will be reactivated and will be able to process transactions.",
+		"title": "Reactivate - {marketName}",
+    "enabled-btn-label": "Reactivate"
 	},
 	"fr": {
-		"enabled-market-success-notification": "Le commerce {marketName} a été activé avec succès.",
+		"enabled-market-success-notification": "Le commerce {marketName} a été réactivé avec succès.",
 		"enabled-text-error": "Le texte doit correspondre au nom du commerce.",
 		"enabled-text-label": "Taper le nom du commerce pour confirmer",
-		"description": "Avertissement ! Si vous continuez, le commerce sera activé et pourra traiter les transactions.",
+		"description": "Avertissement ! Si vous continuez, le commerce sera réactivé et pourra traiter les transactions.",
 		"title": "Réactiver - {marketName}",
     "enabled-btn-label": "Réactiver"
 	}

--- a/Sig.App.Frontend/src/views/transaction/Error.vue
+++ b/Sig.App.Frontend/src/views/transaction/Error.vue
@@ -1,7 +1,7 @@
 <i18n>
 {
 	"en": {
-		"card-cant-be-use-in-market": "The participant cannot make a purchase in this market.",
+		"card-cant-be-use-in-market": "The participant cannot make a purchase at this merchant.",
 		"card-deactivated": "The card is deactivated.",
 		"card-not-found": "QR code does not equate to a known card.",
 		"create-new-transaction-btn": "Create a new transaction",
@@ -10,12 +10,12 @@
 		"title": "Error during payment 🚫"
 	},
 	"fr": {
-		"card-cant-be-use-in-market": "Le·a  participant·e ne peut pas faire d'achat dans ce commerce.",
+		"card-cant-be-use-in-market": "Le·a participant·e ne peut pas faire d'achat dans ce commerce.",
 		"card-deactivated": "La carte est désactivée.",
 		"card-not-found": "Le code QR n'équivaut pas à une cartre connue.",
 		"create-new-transaction-btn": "Créer une nouvelle transaction",
-		"not-enought-fund": "Le·a  participant·e ne possède pas assez de fond.",
-    "card-cant-be-use-in-cash-register": "Le·a  participant·e ne peut pas faire d'achat avec cette caisse.",
+		"not-enought-fund": "Le·a participant·e ne possède pas assez de fond.",
+    "card-cant-be-use-in-cash-register": "Le·a participant·e ne peut pas faire d'achat avec cette caisse.",
 		"title": "Erreur lors du paiement 🚫"
 	}
 }


### PR DESCRIPTION
Ce PR pourrait être incorporé dans la v8.9

- Ajuster du texte sur l'écran de choix de versement manuel
  - À noter : j'ai commenté quelques lignes en dehors du tag `<i18n>` — je suggère d'enlever ces lignes
- Enlever le terme « Disable » pour les commerces
- Remplacer « Enable » par « Reactivate » (cartes et commerces)