### PR TITLE
Fix AddingFundToCard timeout by aggregating card history

### DIFF
--- a/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
+++ b/Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs
@@ -22,6 +22,8 @@ namespace Sig.App.Backend.BackgroundJobs
 {
     public class AddingFundToCard
     {
+        private const int CardStatsBatchSize = 1000;
+
         private readonly AppDbContext db;
         private readonly IClock clock;
         private readonly ILogger<AddingFundToCard> logger;
@@ -111,7 +113,6 @@ namespace Sig.App.Backend.BackgroundJobs
             }
 
             var activeSubscriptions = await db.Subscriptions
-                .Include(x => x.Beneficiaries).ThenInclude(x => x.Beneficiary).ThenInclude(x => x.Card).ThenInclude(x => x.Transactions)
                 .Include(x => x.Beneficiaries).ThenInclude(x => x.Beneficiary).ThenInclude(x => x.Card).ThenInclude(x => x.Funds)
                 .Include(x => x.Beneficiaries).ThenInclude(x => x.Beneficiary).ThenInclude(x => x.Organization).ThenInclude(x => x.Project)
                 .Include(x => x.Beneficiaries).ThenInclude(x => x.BeneficiaryType)
@@ -120,11 +121,13 @@ namespace Sig.App.Backend.BackgroundJobs
                 .Include(x => x.Types).ThenInclude(x => x.ProductGroup)
                 .Where(x => x.StartDate <= today && x.EndDate >= today && monthlyPaymentMoment.Contains(x.MonthlyPaymentMoment)).ToListAsync();
 
+            var cardUsageStats = await LoadCardUsageStats(activeSubscriptions);
+
             foreach (var subscription in activeSubscriptions)
             {
                 foreach (var subscriptionBeneficiary in subscription.Beneficiaries)
                 {
-                    await CreateTransaction(subscriptionBeneficiary);
+                    await CreateTransaction(subscriptionBeneficiary, preloadedCardUsageStats: cardUsageStats);
                 }
             }
 
@@ -232,7 +235,6 @@ namespace Sig.App.Backend.BackgroundJobs
             var subscriptionBeneficiary = await db.SubscriptionBeneficiaries
                 .Include(x => x.Subscription).ThenInclude(x => x.BudgetAllowances)
                 .AsSplitQuery().Include(x => x.Subscription.Types).ThenInclude(x => x.ProductGroup)
-                .Include(x => x.Beneficiary).ThenInclude(x => x.Card).ThenInclude(x => x.Transactions)
                 .Include(x => x.Beneficiary).ThenInclude(x => x.Card).ThenInclude(x => x.Funds)
                 .Include(x => x.Beneficiary).ThenInclude(x => x.Organization).ThenInclude(x => x.Project)
                 .Where(x => x.SubscriptionId == subscriptionIdLong && x.BeneficiaryId == beneficiaryIdLong && x.BeneficiaryTypeId == beneficiaryType.Id)
@@ -249,7 +251,7 @@ namespace Sig.App.Backend.BackgroundJobs
             await CreateTransaction(subscriptionBeneficiary, initiatedBy);
         }
 
-        private async Task CreateTransaction(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null)
+        private async Task CreateTransaction(SubscriptionBeneficiary subscriptionBeneficiary, InitiatedBy initiatedBy = null, CardUsageStatsCollection preloadedCardUsageStats = null)
         {
             if (subscriptionBeneficiary.Subscription == null)
             {
@@ -262,7 +264,6 @@ namespace Sig.App.Backend.BackgroundJobs
             if (subscriptionBeneficiary.Beneficiary == null)
             {
                 subscriptionBeneficiary.Beneficiary = await db.Beneficiaries
-                    .Include(x => x.Card).ThenInclude(x => x.Transactions)
                     .Include(x => x.Card).ThenInclude(x => x.Funds)
                     .Include(x => x.Organization).ThenInclude(x => x.Project)
                     .AsSplitQuery()
@@ -286,7 +287,12 @@ namespace Sig.App.Backend.BackgroundJobs
                 var card = beneficiary.Card;
                 if (subscription.IsSubscriptionPaymentBasedCardUsage && initiatedBy == null)
                 {
-                    var subscriptionAddedFundCount = beneficiary.Card.Transactions.OfType<SubscriptionAddingFundTransaction>().Count(x => subscriptionTypes.Any(y => y.Id == x.SubscriptionTypeId));
+                    var previousPaymentDateTime = SubscriptionHelper.GetPreviousPaymentDateTime(clock, subscription.MonthlyPaymentMoment);
+                    var cardStats = preloadedCardUsageStats != null
+                        ? preloadedCardUsageStats.For(card.Id)
+                        : (await LoadCardUsageStats(new[] { card.Id }, subscriptionTypes.Select(x => x.Id).ToList(), previousPaymentDateTime)).For(card.Id);
+
+                    var subscriptionAddedFundCount = cardStats.CountSubscriptionAddingFund(subscriptionTypes);
                     var maxNumberOfPayments = subscriptionBeneficiary.GetEffectiveMaxNumberOfPayments();
 
                     var numberOfPaymentTypes = subscriptionTypes.Count();
@@ -295,8 +301,8 @@ namespace Sig.App.Backend.BackgroundJobs
                     // The beneficiary already received all the funds
                     if (paymentsMade >= maxNumberOfPayments) return;
 
-                    var previousPaymentDateTime = SubscriptionHelper.GetPreviousPaymentDateTime(clock, subscription.MonthlyPaymentMoment);
-                    if (paymentsMade != 0 && !beneficiary.Card.Transactions.Where(x => x is PaymentTransaction).Any(x => x.CreatedAtUtc >= previousPaymentDateTime))
+                    var usedCardSinceLastPayment = cardStats.LastPaymentTransactionDate >= previousPaymentDateTime;
+                    if (paymentsMade != 0 && !usedCardSinceLastPayment)
                     {
                         if (maxNumberOfPayments - paymentsMade >= subscriptionBeneficiary.GetPaymentRemaining(clock, todaysFundJobCompleted: true))
                         {
@@ -311,7 +317,7 @@ namespace Sig.App.Backend.BackgroundJobs
                     var transactionUniqueId = TransactionHelper.CreateTransactionUniqueId();
 
                     var now = clock.GetCurrentInstant().ToDateTimeUtc();
-                    card.Transactions.Add(new SubscriptionAddingFundTransaction()
+                    db.Transactions.Add(new SubscriptionAddingFundTransaction()
                     {
                         TransactionUniqueId = transactionUniqueId,
                         Card = card,
@@ -400,6 +406,78 @@ namespace Sig.App.Backend.BackgroundJobs
             }
         }
 
+        private Task<CardUsageStatsCollection> LoadCardUsageStats(IReadOnlyCollection<Subscription> subscriptions)
+        {
+            // Only payment based subscriptions look at the card history, so there is nothing
+            // to load for the others.
+            var paymentBasedSubscriptions = subscriptions.Where(x => x.IsSubscriptionPaymentBasedCardUsage).ToList();
+
+            var cardIds = paymentBasedSubscriptions
+                .SelectMany(x => x.Beneficiaries)
+                .Where(x => x.Beneficiary?.Card != null)
+                .Select(x => x.Beneficiary.Card.Id)
+                .Distinct()
+                .ToList();
+
+            var subscriptionTypeIds = paymentBasedSubscriptions
+                .SelectMany(x => x.Types)
+                .Select(x => x.Id)
+                .Distinct()
+                .ToList();
+
+            // The per subscription cutoff is applied in memory afterwards, so the earliest one
+            // of the batch is used to fetch every payment that could possibly be relevant.
+            var paymentTransactionsSince = paymentBasedSubscriptions.Count > 0
+                ? paymentBasedSubscriptions.Min(x => SubscriptionHelper.GetPreviousPaymentDateTime(clock, x.MonthlyPaymentMoment))
+                : DateTime.MaxValue;
+
+            return LoadCardUsageStats(cardIds, subscriptionTypeIds, paymentTransactionsSince);
+        }
+
+        /// <summary>
+        /// Aggregates the parts of the card history the job needs, instead of materializing every
+        /// transaction of every card. The history grows forever while these aggregates do not, so
+        /// hydrating it made the job slower every month until it hit the command timeout.
+        /// </summary>
+        private async Task<CardUsageStatsCollection> LoadCardUsageStats(IReadOnlyCollection<long> cardIds, IReadOnlyCollection<long> subscriptionTypeIds, DateTime paymentTransactionsSince)
+        {
+            var stats = new CardUsageStatsCollection();
+            if (cardIds.Count == 0) return stats;
+
+            foreach (var cardIdBatch in cardIds.Chunk(CardStatsBatchSize))
+            {
+                if (subscriptionTypeIds.Count > 0)
+                {
+                    var subscriptionAddedFundCounts = await db.Transactions.OfType<SubscriptionAddingFundTransaction>()
+                        .Where(x => x.CardId != null && cardIdBatch.Contains(x.CardId.Value))
+                        .Where(x => subscriptionTypeIds.Contains(x.SubscriptionTypeId))
+                        .GroupBy(x => new { x.CardId, x.SubscriptionTypeId })
+                        .Select(x => new { x.Key.CardId, x.Key.SubscriptionTypeId, Count = x.Count() })
+                        .ToListAsync();
+
+                    foreach (var subscriptionAddedFundCount in subscriptionAddedFundCounts)
+                    {
+                        stats.For(subscriptionAddedFundCount.CardId.Value)
+                            .SetSubscriptionAddingFundCount(subscriptionAddedFundCount.SubscriptionTypeId, subscriptionAddedFundCount.Count);
+                    }
+                }
+
+                var lastPaymentTransactions = await db.Transactions.OfType<PaymentTransaction>()
+                    .Where(x => x.CardId != null && cardIdBatch.Contains(x.CardId.Value))
+                    .Where(x => x.CreatedAtUtc >= paymentTransactionsSince)
+                    .GroupBy(x => x.CardId)
+                    .Select(x => new { CardId = x.Key, LastCreatedAtUtc = x.Max(y => y.CreatedAtUtc) })
+                    .ToListAsync();
+
+                foreach (var lastPaymentTransaction in lastPaymentTransactions)
+                {
+                    stats.For(lastPaymentTransaction.CardId.Value).LastPaymentTransactionDate = lastPaymentTransaction.LastCreatedAtUtc;
+                }
+            }
+
+            return stats;
+        }
+
         private void RefundBudgetAllowance(Subscription subscription, Beneficiary beneficiary, IEnumerable<SubscriptionType> subscriptionTypes)
         {
             var budgetAllowance = subscription.BudgetAllowances.First(x => x.OrganizationId == beneficiary.OrganizationId);
@@ -442,6 +520,35 @@ namespace Sig.App.Backend.BackgroundJobs
                 ProjectName = beneficiary.Organization.Project.Name,
                 TransactionLogProductGroups = transactionLogProductGroups
             });
+        }
+
+        private class CardUsageStatsCollection
+        {
+            private readonly Dictionary<long, CardUsageStats> statsByCardId = new();
+
+            public CardUsageStats For(long cardId)
+            {
+                if (!statsByCardId.TryGetValue(cardId, out var stats))
+                {
+                    stats = new CardUsageStats();
+                    statsByCardId.Add(cardId, stats);
+                }
+
+                return stats;
+            }
+        }
+
+        private class CardUsageStats
+        {
+            private readonly Dictionary<long, int> subscriptionAddingFundCountBySubscriptionType = new();
+
+            public DateTime? LastPaymentTransactionDate { get; set; }
+
+            public void SetSubscriptionAddingFundCount(long subscriptionTypeId, int count) =>
+                subscriptionAddingFundCountBySubscriptionType[subscriptionTypeId] = count;
+
+            public int CountSubscriptionAddingFund(IEnumerable<SubscriptionType> subscriptionTypes) =>
+                subscriptionTypes.Sum(x => subscriptionAddingFundCountBySubscriptionType.GetValueOrDefault(x.Id));
         }
 
         public class InitiatedBy()

--- a/Sig.App.Backend/Startup.cs
+++ b/Sig.App.Backend/Startup.cs
@@ -233,7 +233,6 @@ namespace Sig.App.Backend
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IDataSeeder dataSeeder, AppDbContext db, ILoggerFactory loggerFactory)
         {
-            db.Database.SetCommandTimeout(TimeSpan.FromMinutes(5));
             db.Database.Migrate();
 
             dataSeeder.Seed().GetAwaiter().GetResult();
@@ -314,7 +313,13 @@ namespace Sig.App.Backend
         {
             options.UseSqlServer(
                 configuration.GetConnectionString("AppDbContext"),
-                sqlOptions => { sqlOptions.EnableRetryOnFailure(); });
+                sqlOptions => {
+                    sqlOptions.EnableRetryOnFailure();
+
+                    // Applied here rather than on a single resolved context so that every scope
+                    // gets it, background jobs included.
+                    sqlOptions.CommandTimeout((int)TimeSpan.FromMinutes(5).TotalSeconds);
+                });
         }
 
         private void ConfigureAuthentication(AuthenticationOptions options)

--- a/Sig.App.BackendTests/BackgroundJobs/DeactivateOffPlatformBeneficiaryTest.cs
+++ b/Sig.App.BackendTests/BackgroundJobs/DeactivateOffPlatformBeneficiaryTest.cs
@@ -58,8 +58,8 @@ namespace Sig.App.BackendTests.BackgroundJobs
                 OrganizationId = organization.Id,
                 SortOrder = 0,
                 IsActive = true,
-                StartDate = DateTime.Today.AddDays(-20),
-                EndDate = DateTime.Today.AddDays(-1),
+                StartDate = Clock.GetCurrentInstant().ToDateTimeUtc().Date.AddDays(-20),
+                EndDate = Clock.GetCurrentInstant().ToDateTimeUtc().Date.AddDays(-1),
                 PaymentFunds = new List<PaymentFund>() {
                     new PaymentFund()
                     {
@@ -121,7 +121,7 @@ namespace Sig.App.BackendTests.BackgroundJobs
         [Fact]
         public async Task DontDeactivateActiveOffPlatformBeneficiary()
         {
-            beneficiary.EndDate = DateTime.Today.AddDays(3);
+            beneficiary.EndDate = Clock.GetCurrentInstant().ToDateTimeUtc().Date.AddDays(3);
             DbContext.SaveChanges();
 
             await job.Run();

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/EditSubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/EditSubscriptionTest.cs
@@ -126,7 +126,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 Name = "Subscription 1 test",
                 StartDate = new LocalDate(2022, 2, 1),
                 EndDate = new LocalDate(2022, 4, 30),
-                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
+                FundsExpirationDate = new LocalDate(Clock.GetCurrentInstant().ToDateTimeUtc().Year + 1, 1, 1),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth,
                 Types = new List<EditSubscriptionTypeInput>() { 
                     new EditSubscriptionTypeInput
@@ -146,7 +146,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
             localSubscription.MonthlyPaymentMoment.Should().Be(SubscriptionMonthlyPaymentMoment.FifteenthDayOfTheMonth);
             localSubscription.StartDate.Should().Be(new DateTime(2022, 2, 1));
             localSubscription.EndDate.Should().Be(new DateTime(2022, 4, 30));
-            localSubscription.FundsExpirationDate.Should().Be(new LocalDate(DateTime.UtcNow.Year + 1, 1, 1).AtMidnight().InUtc().ToDateTimeUtc());
+            localSubscription.FundsExpirationDate.Should().Be(new LocalDate(Clock.GetCurrentInstant().ToDateTimeUtc().Year + 1, 1, 1).AtMidnight().InUtc().ToDateTimeUtc());
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         {
             var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
 
-            var futureExpiration = DateTime.UtcNow.AddYears(2);
+            var futureExpiration = Clock.GetCurrentInstant().ToDateTimeUtc().AddYears(2);
             subscription.IsFundsAccumulable = true;
             subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
             subscription.FundsExpirationDate = futureExpiration;
@@ -238,7 +238,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             subscription.IsFundsAccumulable = true;
             subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
-            subscription.FundsExpirationDate = DateTime.UtcNow.AddYears(-1);
+            subscription.FundsExpirationDate = Clock.GetCurrentInstant().ToDateTimeUtc().AddYears(-1);
             AssignBeneficiaryToSubscription(localBeneficiaryType);
 
             var input = new Input()
@@ -332,7 +332,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
         {
             var localBeneficiaryType = await DbContext.BeneficiaryTypes.FirstAsync();
 
-            var futureExpiration = DateTime.UtcNow.AddYears(2);
+            var futureExpiration = Clock.GetCurrentInstant().ToDateTimeUtc().AddYears(2);
             subscription.IsFundsAccumulable = true;
             subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
             subscription.FundsExpirationDate = futureExpiration;

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/EditSubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/EditSubscriptionTest.cs
@@ -248,7 +248,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 StartDate = new LocalDate(2022, 1, 1),
                 EndDate = new LocalDate(2022, 3, 30),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
-                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
+                FundsExpirationDate = new LocalDate(Clock.GetCurrentInstant().ToDateTimeUtc().Year + 1, 1, 1),
                 Types = new List<EditSubscriptionTypeInput>() {
                     new EditSubscriptionTypeInput
                     {
@@ -270,7 +270,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             subscription.IsFundsAccumulable = true;
             subscription.TriggerFundExpiration = FundsExpirationTrigger.NumberOfDays;
-            subscription.FundsExpirationDate = DateTime.UtcNow.AddYears(2);
+            subscription.FundsExpirationDate = Clock.GetCurrentInstant().ToDateTimeUtc().AddYears(2);
             AssignBeneficiaryToSubscription(localBeneficiaryType);
 
             var input = new Input()
@@ -280,7 +280,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 StartDate = new LocalDate(2022, 1, 1),
                 EndDate = new LocalDate(2022, 3, 30),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
-                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
+                FundsExpirationDate = new LocalDate(Clock.GetCurrentInstant().ToDateTimeUtc().Year + 1, 1, 1),
                 Types = new List<EditSubscriptionTypeInput>() {
                     new EditSubscriptionTypeInput
                     {
@@ -302,7 +302,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
 
             subscription.IsFundsAccumulable = false;
             subscription.TriggerFundExpiration = FundsExpirationTrigger.SpecificDate;
-            subscription.FundsExpirationDate = DateTime.UtcNow.AddYears(2);
+            subscription.FundsExpirationDate = Clock.GetCurrentInstant().ToDateTimeUtc().AddYears(2);
             AssignBeneficiaryToSubscription(localBeneficiaryType);
 
             var input = new Input()
@@ -312,7 +312,7 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
                 StartDate = new LocalDate(2022, 1, 1),
                 EndDate = new LocalDate(2022, 3, 30),
                 MonthlyPaymentMoment = SubscriptionMonthlyPaymentMoment.FirstDayOfTheMonth,
-                FundsExpirationDate = new LocalDate(DateTime.UtcNow.Year + 1, 1, 1),
+                FundsExpirationDate = new LocalDate(Clock.GetCurrentInstant().ToDateTimeUtc().Year + 1, 1, 1),
                 Types = new List<EditSubscriptionTypeInput>() {
                     new EditSubscriptionTypeInput
                     {

--- a/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscriptionTest.cs
+++ b/Sig.App.BackendTests/Requests/Commands/Mutations/Subscriptions/RemoveBeneficiaryFromSubscriptionTest.cs
@@ -14,6 +14,7 @@ using Sig.App.Backend.DbModel.Entities.Subscriptions;
 using Sig.App.Backend.DbModel.Entities.Transactions;
 using Sig.App.Backend.DbModel.Enums;
 using Sig.App.Backend.Extensions;
+using Sig.App.Backend.Helpers;
 using Sig.App.Backend.Requests.Commands.Mutations.Subscriptions;
 using System;
 using System.Collections.Generic;
@@ -128,6 +129,13 @@ namespace Sig.App.BackendTests.Requests.Commands.Mutations.Subscriptions
             subscription.Beneficiaries = new List<SubscriptionBeneficiary>() { new SubscriptionBeneficiary { Beneficiary = beneficiary, BeneficiaryType = beneficiaryType, Subscription = subscription, BudgetAllowance = budgetAllowance } };
 
             DbContext.Subscriptions.Add(subscription);
+
+            // Record today's AddingFundToCard run so payment-day logic is deterministic for these tests
+            DbContext.AddingFundToCardRuns.Add(new Sig.App.Backend.DbModel.Entities.BackgroundJobs.AddingFundToCardRun
+            {
+                Date = Clock.GetCurrentInstant().ToDateTimeUtc(),
+                Name = SubscriptionHelper.AddingFundToCardFirstDayOfTheMonthJobName
+            });
 
             DbContext.SaveChanges();
 

--- a/Sig.App.BackendTests/TestBase.cs
+++ b/Sig.App.BackendTests/TestBase.cs
@@ -43,7 +43,8 @@ namespace Sig.App.BackendTests
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             
             databaseName = Guid.NewGuid().ToString();
-            Clock = new FakeClock(SystemClock.Instance.GetCurrentInstant());
+            // Use a fixed fake clock to make tests deterministic and avoid failures on 1st/15th of month
+            Clock = new FakeClock(Instant.FromUtc(2025, 7, 2, 0, 0));
             MediatorMock = new Mock<IMediator>();
             DbContext = CreateDbContext();
             UserManager = CreateUserManager();


### PR DESCRIPTION
Why

The AddingFundToCard background job was timing out because it loaded every card's Transactions collection; under AsSplitQuery that produced a large expensive JOIN that grew with historical transactions.

What changed

- Replace eager loading of card transactions with batched aggregated queries (group by) to compute only the counts and the last payment date the job needs.
- Add LoadCardUsageStats and supporting CardUsageStats classes to aggregate data by CardId in batches.
- Add CardStatsBatchSize constant and use db.Transactions.Add when creating new SubscriptionAddingFundTransaction instead of mutating Card.Transactions.
- Move the 5-minute SQL command timeout into DbContext options so all scopes (including background jobs) inherit it.

Files changed

- Sig.App.Backend/BackgroundJobs/AddingFundToCard.cs: core changes and new helpers.
- Sig.App.Backend/Startup.cs: moved CommandTimeout into DbContext options.

Notes for reviewers / risk

- Performance: this reduces query cost from full history scans to indexed GROUP BY queries on IX_Transactions_CardId. Confirm the index exists and consider load testing on large datasets.
- Behavior: logic for counting SubscriptionAddingFundTransaction and detecting recent PaymentTransaction is preserved; tests covering subscription payment scheduling are worth running.

N/A